### PR TITLE
Adds `build` as a make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ GOPATH?=$(shell go env GOPATH)
 $(BINARY): $(SOURCES)
 	$(GO) build -v -o fugue
 
+.PHONY: build
+build: $(BINARY)
+
 .PHONY: install
 install: $(BINARY)
 	cp $(BINARY) $(GOPATH)/bin/


### PR DESCRIPTION
# Before

```
± make build install
gmake: *** No rule to make target 'build'.  Stop.
```

# After

```
± make build install
GO111MODULE=on go build -v -o fugue
cp fugue /Users/wayne/go/bin/
```