### PR TITLE
[RM-2431] Make family argument case insensitive

### DIFF
--- a/cmd/getScanComplianceByResourceTypes.go
+++ b/cmd/getScanComplianceByResourceTypes.go
@@ -50,7 +50,7 @@ func NewGetScanComplianceByResourceTypesCommand() *cobra.Command {
 				params.ResourceType = opts.ResourceTypes
 			}
 			if len(opts.Families) > 0 {
-				params.Family = opts.Families
+				params.Family = format.NormalizeStrings(opts.Families)
 			}
 
 			resp, err := client.Scans.GetComplianceByResourceTypes(params, auth)

--- a/cmd/getScanComplianceByRules.go
+++ b/cmd/getScanComplianceByRules.go
@@ -40,10 +40,10 @@ func NewGetScanComplianceByRulesCommand() *cobra.Command {
 				params.MaxItems = &opts.MaxItems
 			}
 			if len(opts.Results) > 0 {
-				params.Result = opts.Results
+				params.Result = format.NormalizeStrings(opts.Results)
 			}
 			if len(opts.Families) > 0 {
-				params.Family = opts.Families
+				params.Family = format.NormalizeStrings(opts.Families)
 			}
 
 			resp, err := client.Scans.GetComplianceByRules(params, auth)

--- a/format/format.go
+++ b/format/format.go
@@ -169,3 +169,12 @@ func Table(opts TableOpts) ([]string, error) {
 
 	return rows, nil
 }
+
+// NormalizeStrings normalizes a slice of strings to all uppercase
+func NormalizeStrings(input []string) []string {
+	output := make([]string, len(input))
+	for i, s := range input {
+		output[i] = strings.ToUpper(s)
+	}
+	return output
+}


### PR DESCRIPTION
# WHY
The `family` argument to get rule by resource type/rule is case-sensitive 

# WHAT
Add normalization to make it case-insensitive.

