### PR TITLE
[RM-3513] Support advanced rules, Azure, and Govcloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,13 @@
 #
 version: 2.1
 
-commands:
-  tf-install:
-    steps:
-      - run:
-          name: go-test
-          command: |
-            go test -test.v ./...
-
 jobs:
   build:
     docker:
       - image: circleci/golang:1.12
     environment:
       GOMODULE111=on
+    working_directory: /go/src/github.com/fugue/fugue-client
     steps:
       - checkout
-      - go-test
+      - run: go test -test.v ./...

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,5 +13,5 @@ jobs:
     working_directory: /go/src/github.com/fugue/fugue-client
     steps:
       - checkout
-      - run: go test -test.v ./...
+      - run: make test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,3 +14,4 @@ jobs:
     steps:
       - checkout
       - run: go test -test.v ./...
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2.1
+
+commands:
+  tf-install:
+    steps:
+      - run:
+          name: go-test
+          command: |
+            go test -test.v ./...
+
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+    environment:
+      GOMODULE111=on
+    steps:
+      - checkout
+      - go-test

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ gen: $(SWAGGER)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_RULE_SRC)
 
+.PHONY: test
+test:
+	$(GO) test -test.v ./...
+
 .PHONY: clean
 clean:
 	rm -f $(BINARY)

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -63,17 +63,9 @@ func (rego *regoFile) ParseText() error {
 		return ""
 	}
 
-	rego.Description = getHeader("Description")
 	rego.Provider = getHeader("Provider")
-
-	rt := getHeader("Resource-Type")
-	if strings.EqualFold(rt, "MULTIPLE") {
-		rego.ResourceType = rt
-	} else if strings.EqualFold(rego.Provider[0:3], "AWS") {
-		rego.ResourceType = "AWS." + rt
-	} else {
-		rego.ResourceType = rego.Provider + "." + rt
-	}
+	rego.ResourceType = getHeader("Resource-Type")
+	rego.Description = getHeader("Description")
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -62,9 +62,18 @@ func (rego *regoFile) ParseText() error {
 		}
 		return ""
 	}
-	rego.ResourceType = getHeader("Resource-Type")
+
 	rego.Description = getHeader("Description")
 	rego.Provider = getHeader("Provider")
+
+	rt := getHeader("Resource-Type")
+	if strings.EqualFold(rt, "MULTIPLE") {
+		rego.ResourceType = rt
+	} else if strings.EqualFold(rego.Provider[0:3], "AWS") {
+		rego.ResourceType = "AWS." + rt
+	} else {
+		rego.ResourceType = rego.Provider + "." + rt
+	}
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -21,7 +21,6 @@ type regoFile struct {
 	Text         string
 }
 
-var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]([\w]+)[.]([\w]+)`)
 var regoDescriptionHeader = regexp.MustCompile(`([dD]escription\:[\t ]*?)(.*)`)
 
 func loadRego(path string) (*regoFile, error) {
@@ -84,6 +83,9 @@ func loadRego(path string) (*regoFile, error) {
 	}
 	if rego.Description == "" {
 		return nil, errors.New("expected a description by the header \"Description\"")
+
+var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]((?i)(MULTIPLE)|([\w]+[.][\w]+))`)
+var regoDescriptionHeader = regexp.MustCompile(`([dD]escription\:[\t ]*?)(.*)`)
 	}
 	return &rego, nil
 }

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -24,15 +24,6 @@ type regoFile struct {
 var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]([\w]+)[.]([\w]+)`)
 var regoDescriptionHeader = regexp.MustCompile(`([dD]escription\:[\t ]*?)(.*)`)
 
-func pathToRuleName(path string) string {
-	baseName := filepath.Base(path)
-	extension := strings.ToLower(filepath.Ext(path))
-	if extension != ".rego" {
-		return ""
-	}
-	return baseName[:len(baseName)-len(extension)]
-}
-
 func loadRego(path string) (*regoFile, error) {
 
 	baseName := filepath.Base(path)

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -59,9 +59,13 @@ func loadRego(path string) (*regoFile, error) {
 		// Look for a resource type type denoted by the correct header
 		if rego.ResourceType == "" {
 			match := regoResourceTypeHeader.FindStringSubmatch(line)
-			if len(match) == 5 {
-				rego.ResourceType = strings.Join(match[2:5], ".")
-				rego.Provider = strings.ToUpper(match[2])
+			if len(match) == 6 {
+				rego.Provider = match[2]
+				if match[4] == "" {
+					rego.ResourceType = strings.Join(match[2:4], ".")
+				} else {
+					rego.ResourceType = strings.ToUpper(match[3])
+				}
 				continue
 			} else {
 				return nil, errors.New("unexpected resource type definition")

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/fugue/fugue-client/client/custom_rules"
@@ -80,9 +79,6 @@ func (rego *regoFile) ParseText() error {
 
 	return nil
 }
-
-var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]((MULTIPLE)|([\w]+[.][\w]+))`)
-var regoDescriptionHeader = regexp.MustCompile(`([dD]escription\:[\t ]*?)(.*)`)
 
 func loadRego(path string) (*regoFile, error) {
 

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -66,7 +66,7 @@ func (rego *regoFile) ParseText() error {
 	return nil
 }
 
-var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]((?i)(MULTIPLE)|([\w]+[.][\w]+))`)
+var regoResourceTypeHeader = regexp.MustCompile(`([rR]esource-[tT]ype\:[\t ]*?)([\w]+)[.]((MULTIPLE)|([\w]+[.][\w]+))`)
 var regoDescriptionHeader = regexp.MustCompile(`([dD]escription\:[\t ]*?)(.*)`)
 
 func loadRego(path string) (*regoFile, error) {

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -28,14 +28,6 @@ func TestParseRego(t *testing.T) {
 			"MULTIPLE",
 		},
 		{
-			"multiple-aws-mixed",
-			&regoFile{
-				Text: "# Resource-Type: AWS.mulTiPLe\n# Description: fake\n\ndeny{}",
-			},
-			"AWS",
-			"MULTIPLE",
-		},
-		{
 			"single-aws-govcloud",
 			&regoFile{
 				Text: "# Resource-Type: AWS_GOVCLOUD.EC2.Instance\n# Description: fake\n\ndeny{}",

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -14,7 +14,11 @@ func TestParseRego(t *testing.T) {
 		{
 			"single-aws",
 			&regoFile{
-				Text: "# Resource-Type: AWS.EC2.Instance\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: AWS.EC2.Instance
+# Description: fake
+# Provider: AWS
+deny{}`,
 			},
 			"AWS",
 			"AWS.EC2.Instance",
@@ -22,7 +26,11 @@ func TestParseRego(t *testing.T) {
 		{
 			"multiple-aws",
 			&regoFile{
-				Text: "# Resource-Type: AWS.MULTIPLE\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: MULTIPLE
+# Description: fake
+# Provider: AWS
+deny{}`,
 			},
 			"AWS",
 			"MULTIPLE",
@@ -30,15 +38,25 @@ func TestParseRego(t *testing.T) {
 		{
 			"single-aws-govcloud",
 			&regoFile{
-				Text: "# Resource-Type: AWS_GOVCLOUD.EC2.Instance\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: AWS.EC2.Instance
+# Provider: AWS_GOVCLOUD
+# Description: fake
+
+deny{}`,
 			},
 			"AWS_GOVCLOUD",
-			"AWS_GOVCLOUD.EC2.Instance",
+			"AWS.EC2.Instance",
 		},
 		{
 			"multiple-aws-govcloud",
 			&regoFile{
-				Text: "# Resource-Type: AWS_GOVCLOUD.MULTIPLE\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: MULTIPLE
+# Description: fake
+# Provider: AWS_GOVCLOUD
+
+deny{}`,
 			},
 			"AWS_GOVCLOUD",
 			"MULTIPLE",
@@ -46,7 +64,11 @@ func TestParseRego(t *testing.T) {
 		{
 			"single-azure",
 			&regoFile{
-				Text: "# Resource-Type: Azure.Compute.VirtualMachine\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: Azure.Compute.VirtualMachine
+# Description: fake
+# Provider: Azure
+deny{}`,
 			},
 			"Azure",
 			"Azure.Compute.VirtualMachine",
@@ -54,7 +76,11 @@ func TestParseRego(t *testing.T) {
 		{
 			"multiple-azure",
 			&regoFile{
-				Text: "# Resource-Type: Azure.MULTIPLE\n# Description: fake\n\ndeny{}",
+				Text: `
+# Resource-Type: MULTIPLE
+# Description: fake
+# Provider: Azure
+deny{}`,
 			},
 			"Azure",
 			"MULTIPLE",

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -15,9 +15,9 @@ func TestParseRego(t *testing.T) {
 			"single-aws",
 			&regoFile{
 				Text: `
-# Resource-Type: AWS.EC2.Instance
-# Description: fake
 # Provider: AWS
+# Resource-Type: EC2.Instance
+# Description: fake
 deny{}`,
 			},
 			"AWS",
@@ -27,9 +27,9 @@ deny{}`,
 			"multiple-aws",
 			&regoFile{
 				Text: `
+# Provider: AWS
 # Resource-Type: MULTIPLE
 # Description: fake
-# Provider: AWS
 deny{}`,
 			},
 			"AWS",
@@ -39,8 +39,8 @@ deny{}`,
 			"single-aws-govcloud",
 			&regoFile{
 				Text: `
-# Resource-Type: AWS.EC2.Instance
 # Provider: AWS_GOVCLOUD
+# Resource-Type: EC2.Instance
 # Description: fake
 
 deny{}`,
@@ -52,9 +52,9 @@ deny{}`,
 			"multiple-aws-govcloud",
 			&regoFile{
 				Text: `
+# Provider: AWS_GOVCLOUD
 # Resource-Type: MULTIPLE
 # Description: fake
-# Provider: AWS_GOVCLOUD
 
 deny{}`,
 			},
@@ -65,9 +65,9 @@ deny{}`,
 			"single-azure",
 			&regoFile{
 				Text: `
-# Resource-Type: Azure.Compute.VirtualMachine
-# Description: fake
 # Provider: Azure
+# Resource-Type: Compute.VirtualMachine
+# Description: fake
 deny{}`,
 			},
 			"Azure",
@@ -77,13 +77,28 @@ deny{}`,
 			"multiple-azure",
 			&regoFile{
 				Text: `
+# Provider: Azure
 # Resource-Type: MULTIPLE
 # Description: fake
-# Provider: Azure
 deny{}`,
 			},
 			"Azure",
 			"MULTIPLE",
+		},
+		{
+			"becki1-aws-s3-bucket-sse",
+			&regoFile{
+				Text: `
+# Provider: AWS_GOVCLOUD
+# Resource-Type: S3.Bucket
+# Description: SSE encryption should be enabled for S3 buckets (AES-256 or KMS).
+
+allow {
+  input.server_side_encryption_configuration[_].rule[_][_][_].sse_algorithm = _
+}`,
+			},
+			"AWS_GOVCLOUD",
+			"AWS.S3.Bucket",
 		},
 	}
 

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParseRego(t *testing.T) {
+	tests := []struct {
+		name        string
+		rego        *regoFile
+		expProvider string
+		expResource string
+	}{
+		{
+			"single-aws",
+			&regoFile{
+				Text: "# Resource-Type: AWS.EC2.Instance\n# Description: fake\n\ndeny{}",
+			},
+			"AWS",
+			"AWS.EC2.Instance",
+		},
+		{
+			"multiple-aws",
+			&regoFile{
+				Text: "# Resource-Type: AWS.MULTIPLE\n# Description: fake\n\ndeny{}",
+			},
+			"AWS",
+			"MULTIPLE",
+		},
+		{
+			"multiple-aws-mixed",
+			&regoFile{
+				Text: "# Resource-Type: AWS.mulTiPLe\n# Description: fake\n\ndeny{}",
+			},
+			"AWS",
+			"MULTIPLE",
+		},
+		{
+			"single-aws-govcloud",
+			&regoFile{
+				Text: "# Resource-Type: AWS_GOVCLOUD.EC2.Instance\n# Description: fake\n\ndeny{}",
+			},
+			"AWS_GOVCLOUD",
+			"AWS_GOVCLOUD.EC2.Instance",
+		},
+		{
+			"multiple-aws-govcloud",
+			&regoFile{
+				Text: "# Resource-Type: AWS_GOVCLOUD.MULTIPLE\n# Description: fake\n\ndeny{}",
+			},
+			"AWS_GOVCLOUD",
+			"MULTIPLE",
+		},
+		{
+			"single-azure",
+			&regoFile{
+				Text: "# Resource-Type: Azure.Compute.VirtualMachine\n# Description: fake\n\ndeny{}",
+			},
+			"Azure",
+			"Azure.Compute.VirtualMachine",
+		},
+		{
+			"multiple-azure",
+			&regoFile{
+				Text: "# Resource-Type: Azure.MULTIPLE\n# Description: fake\n\ndeny{}",
+			},
+			"Azure",
+			"MULTIPLE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rego.ParseText()
+
+			if err != nil {
+				t.Errorf("Error in parseRego %s", err.Error())
+			}
+			if tt.rego.Provider != tt.expProvider {
+				t.Errorf("Expected %s, actual %s", tt.expProvider, tt.rego.Provider)
+			}
+			if tt.rego.ResourceType != tt.expResource {
+				t.Errorf("Expected %s, actual %s", tt.expResource, tt.rego.ResourceType)
+			}
+		})
+	}
+}

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -16,7 +16,7 @@ func TestParseRego(t *testing.T) {
 			&regoFile{
 				Text: `
 # Provider: AWS
-# Resource-Type: EC2.Instance
+# Resource-Type: AWS.EC2.Instance
 # Description: fake
 deny{}`,
 			},
@@ -40,7 +40,7 @@ deny{}`,
 			&regoFile{
 				Text: `
 # Provider: AWS_GOVCLOUD
-# Resource-Type: EC2.Instance
+# Resource-Type: AWS.EC2.Instance
 # Description: fake
 
 deny{}`,
@@ -66,7 +66,7 @@ deny{}`,
 			&regoFile{
 				Text: `
 # Provider: Azure
-# Resource-Type: Compute.VirtualMachine
+# Resource-Type: Azure.Compute.VirtualMachine
 # Description: fake
 deny{}`,
 			},
@@ -90,7 +90,7 @@ deny{}`,
 			&regoFile{
 				Text: `
 # Provider: AWS_GOVCLOUD
-# Resource-Type: S3.Bucket
+# Resource-Type: AWS.S3.Bucket
 # Description: SSE encryption should be enabled for S3 buckets (AES-256 or KMS).
 
 allow {


### PR DESCRIPTION
# What

Fixes inability to support Govcloud, Azure, and advanced rules with `Resource-Type` header. 

# Supported Examples

```
Provider: AWS
Resource-Type: EC2.Instance
```

```
Provider: AWS
Resource-Type: MULTIPLE
```

```
Provider: AWS_GOVCLOUD
Resource-Type: EC2.Instance
```

```
Provider: AWS_GOVCLOUD
Resource-Type: MULTIPLE
```

```
Provider: Azure
Resource-Type: Compute.VirtualMachine
```

```
Provider: Azure
Resource-Type: MULTIPLE
```

# Jira

https://luminal.atlassian.net/browse/RM-3513

# TODO

- [x] Add running tests to CI