### PR TITLE
Bugfix unix pipes deadlock

### DIFF
--- a/cmd/getEnvironment.go
+++ b/cmd/getEnvironment.go
@@ -91,9 +91,9 @@ func NewGetEnvironmentCommand() *cobra.Command {
 				}
 			case "aws_govcloud":
 				items = append(items, Item{"ROLE", env.ProviderOptions.AwsGovcloud.RoleArn})
-				if env.ProviderOptions.Aws.Region != "" {
+				if env.ProviderOptions.AwsGovcloud.Region != "" {
 					items = append(items, Item{"REGION", env.ProviderOptions.AwsGovcloud.Region})
-				} else if len(env.ProviderOptions.Aws.Regions) > 0 {
+				} else if len(env.ProviderOptions.AwsGovcloud.Regions) > 0 {
 					items = append(items, Item{"REGIONS", strings.Join(env.ProviderOptions.AwsGovcloud.Regions, ",")})
 				}
 			case "azure":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -162,6 +162,7 @@ func Execute(version, commit string) {
 
 		doneOut()
 		capturedErr, _ := doneErr()
+
 		outStr := jsonOutput(capturedErr)
 		fmt.Println(outStr)
 	} else {
@@ -203,6 +204,14 @@ func initConfig() {
 // Fatal prints the message (if provided) and then exits.
 func Fatal(msg string, code int) {
 	if len(msg) > 0 {
+		// ensure error prefix
+		if !strings.HasPrefix(msg, "error: ") {
+			msg = fmt.Sprintf("error: %s", msg)
+		}
+		// add newline if needed
+		if !strings.HasSuffix(msg, "\n") {
+			msg += "\n"
+		}
 
 		if isOutputJSON() {
 			doneOut()
@@ -213,13 +222,9 @@ func Fatal(msg string, code int) {
 			if outStr != "" {
 				fmt.Fprintln(os.Stderr, outStr)
 			} else {
-				fmt.Fprintf(os.Stderr, "{\n\t\"error\": \"%s.\"\n}\n", msg)
+				fmt.Fprint(os.Stderr, msg)
 			}
 		} else {
-			// add newline if needed
-			if !strings.HasSuffix(msg, "\n") {
-				msg += "\n"
-			}
 			fmt.Fprint(os.Stderr, msg)
 		}
 


### PR DESCRIPTION
Fix when `fugue list environments --output json` hangs.

The fix use goroutines to avoid the unix pipes deadlock: We need to read from both pipes at the same time.`
