### PR TITLE
Turn Off Scheduled Scans When Scan Interval Set to 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GOPATH?=$(shell go env GOPATH)
 
 UPDATE_ENV_SRC=models/update_environment_input.go
 UPDATE_RULE_SRC=models/update_custom_rule_input.go
+CREATE_ENV_SRC=models/create_environment_input.go
 
 GOSWAGGER=docker run --rm -it \
 	--volume $(shell pwd):/fugue-client \
@@ -49,6 +50,8 @@ gen: $(SWAGGER)
 	sed -i "" "s/Remediation bool/Remediation *bool/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_RULE_SRC)
+	sed -i "" "s/ScanInterval int64/ScanInterval *int64/g" $(CREATE_ENV_SRC)
+	sed -i "" "s/int64(m.ScanInterval)/int64(*m.ScanInterval)/g" $(CREATE_ENV_SRC)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ gen: $(SWAGGER)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_RULE_SRC)
 	sed -i "" "s/ScanInterval int64/ScanInterval *int64/g" $(CREATE_ENV_SRC)
+	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(CREATE_ENV_SRC)
 	sed -i "" "s/int64(m.ScanInterval)/int64(*m.ScanInterval)/g" $(CREATE_ENV_SRC)
 
 .PHONY: test

--- a/cmd/createAwsEnvironment.go
+++ b/cmd/createAwsEnvironment.go
@@ -62,15 +62,22 @@ func NewCreateAwsEnvironmentCommand() *cobra.Command {
 				surveyTypes = resp.Payload.ResourceTypes
 			}
 
+			scanInterval := opts.ScanInterval
+			var scanIntervalPtr *int64
+			if opts.ScanInterval > 0 {
+				scanIntervalPtr = &scanInterval
+			}
+			scanScheduleEnabled := scanInterval != 0
+
 			params := environments.NewCreateEnvironmentParams()
 			params.Environment = &models.CreateEnvironmentInput{
 				ComplianceFamilies:     opts.ComplianceFamilies,
 				Name:                   opts.Name,
 				Provider:               opts.Provider,
-				ScanInterval:           opts.ScanInterval,
+				ScanInterval:           scanIntervalPtr,
 				SurveyResourceTypes:    surveyTypes,
 				RemediateResourceTypes: opts.RemediationResourceTypes,
-				ScanScheduleEnabled:    true,
+				ScanScheduleEnabled:    scanScheduleEnabled,
 			}
 
 			providerOpts := &models.ProviderOptionsAws{
@@ -164,7 +171,7 @@ func NewCreateAwsEnvironmentCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.Regions, "regions", []string{}, "AWS regions (default all regions)")
 	cmd.Flags().StringVar(&opts.Provider, "provider", "", "Provider if cannot be resolved from regions")
 	cmd.Flags().StringVar(&opts.Role, "role", "", "AWS IAM role arn")
-	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 86400, "Scan interval (seconds)")
+	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 0, "Scan interval (seconds)")
 	cmd.Flags().StringSliceVar(&opts.ComplianceFamilies, "compliance-families", []string{}, "Compliance families")
 	cmd.Flags().StringSliceVar(&opts.RemediationResourceTypes, "remediation-resource-types", []string{}, "Remediation resource types")
 	cmd.Flags().StringSliceVar(&opts.SurveyResourceTypes, "survey-resource-types", nil, "Survey resource types (defaults to all available types)")

--- a/cmd/createAwsEnvironment.go
+++ b/cmd/createAwsEnvironment.go
@@ -62,12 +62,11 @@ func NewCreateAwsEnvironmentCommand() *cobra.Command {
 				surveyTypes = resp.Payload.ResourceTypes
 			}
 
-			scanInterval := opts.ScanInterval
+			scanScheduleEnabled := opts.ScanInterval != 0
 			var scanIntervalPtr *int64
-			if opts.ScanInterval > 0 {
-				scanIntervalPtr = &scanInterval
+			if scanScheduleEnabled {
+				scanIntervalPtr = &opts.ScanInterval
 			}
-			scanScheduleEnabled := scanInterval != 0
 
 			params := environments.NewCreateEnvironmentParams()
 			params.Environment = &models.CreateEnvironmentInput{
@@ -77,7 +76,7 @@ func NewCreateAwsEnvironmentCommand() *cobra.Command {
 				ScanInterval:           scanIntervalPtr,
 				SurveyResourceTypes:    surveyTypes,
 				RemediateResourceTypes: opts.RemediationResourceTypes,
-				ScanScheduleEnabled:    scanScheduleEnabled,
+				ScanScheduleEnabled:    &scanScheduleEnabled,
 			}
 
 			providerOpts := &models.ProviderOptionsAws{
@@ -171,7 +170,7 @@ func NewCreateAwsEnvironmentCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.Regions, "regions", []string{}, "AWS regions (default all regions)")
 	cmd.Flags().StringVar(&opts.Provider, "provider", "", "Provider if cannot be resolved from regions")
 	cmd.Flags().StringVar(&opts.Role, "role", "", "AWS IAM role arn")
-	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 0, "Scan interval (seconds)")
+	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 86400, "Scan interval (seconds)")
 	cmd.Flags().StringSliceVar(&opts.ComplianceFamilies, "compliance-families", []string{}, "Compliance families")
 	cmd.Flags().StringSliceVar(&opts.RemediationResourceTypes, "remediation-resource-types", []string{}, "Remediation resource types")
 	cmd.Flags().StringSliceVar(&opts.SurveyResourceTypes, "survey-resource-types", nil, "Survey resource types (defaults to all available types)")

--- a/cmd/createAzureEnvironment.go
+++ b/cmd/createAzureEnvironment.go
@@ -35,15 +35,22 @@ func NewCreateAzureEnvironmentCommand() *cobra.Command {
 
 			client, auth := getClient()
 
+			scanInterval := opts.ScanInterval
+			var scanIntervalPtr *int64
+			if opts.ScanInterval > 0 {
+				scanIntervalPtr = &scanInterval
+			}
+			scanScheduleEnabled := scanInterval != 0
+
 			params := environments.NewCreateEnvironmentParams()
 			params.Environment = &models.CreateEnvironmentInput{
 				ComplianceFamilies:     opts.ComplianceFamilies,
 				Name:                   opts.Name,
 				Provider:               "azure",
-				ScanInterval:           opts.ScanInterval,
+				ScanInterval:           scanIntervalPtr,
 				SurveyResourceTypes:    []string{},
 				RemediateResourceTypes: []string{},
-				ScanScheduleEnabled:    true,
+				ScanScheduleEnabled:    scanScheduleEnabled,
 				ProviderOptions: &models.ProviderOptions{
 					Azure: &models.ProviderOptionsAzure{
 						ApplicationID:           opts.ApplicationID,
@@ -94,7 +101,7 @@ func NewCreateAzureEnvironmentCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.SubscriptionID, "sub", "", "Azure Subscription ID")
 	cmd.Flags().StringVar(&opts.TenantID, "tenant", "", "Azure Tenant ID")
 
-	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 86400, "Scan interval (seconds)")
+	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 0, "Scan interval (seconds)")
 	cmd.Flags().StringSliceVar(&opts.ComplianceFamilies, "compliance-families", []string{}, "Compliance families")
 	cmd.Flags().StringSliceVar(&opts.RemediateResourceGroups, "remediation-resource-groups", []string{}, "Remediation resource groups")
 	cmd.Flags().StringSliceVar(&opts.SurveyResourceGroups, "survey-resource-groups", nil, "Survey resource groups")

--- a/cmd/createAzureEnvironment.go
+++ b/cmd/createAzureEnvironment.go
@@ -35,12 +35,11 @@ func NewCreateAzureEnvironmentCommand() *cobra.Command {
 
 			client, auth := getClient()
 
-			scanInterval := opts.ScanInterval
+			scanScheduleEnabled := opts.ScanInterval != 0
 			var scanIntervalPtr *int64
-			if opts.ScanInterval > 0 {
-				scanIntervalPtr = &scanInterval
+			if scanScheduleEnabled {
+				scanIntervalPtr = &opts.ScanInterval
 			}
-			scanScheduleEnabled := scanInterval != 0
 
 			params := environments.NewCreateEnvironmentParams()
 			params.Environment = &models.CreateEnvironmentInput{
@@ -50,7 +49,7 @@ func NewCreateAzureEnvironmentCommand() *cobra.Command {
 				ScanInterval:           scanIntervalPtr,
 				SurveyResourceTypes:    []string{},
 				RemediateResourceTypes: []string{},
-				ScanScheduleEnabled:    scanScheduleEnabled,
+				ScanScheduleEnabled:    &scanScheduleEnabled,
 				ProviderOptions: &models.ProviderOptions{
 					Azure: &models.ProviderOptionsAzure{
 						ApplicationID:           opts.ApplicationID,
@@ -101,7 +100,7 @@ func NewCreateAzureEnvironmentCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.SubscriptionID, "sub", "", "Azure Subscription ID")
 	cmd.Flags().StringVar(&opts.TenantID, "tenant", "", "Azure Tenant ID")
 
-	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 0, "Scan interval (seconds)")
+	cmd.Flags().Int64Var(&opts.ScanInterval, "scan-interval", 86400, "Scan interval (seconds)")
 	cmd.Flags().StringSliceVar(&opts.ComplianceFamilies, "compliance-families", []string{}, "Compliance families")
 	cmd.Flags().StringSliceVar(&opts.RemediateResourceGroups, "remediation-resource-groups", []string{}, "Remediation resource groups")
 	cmd.Flags().StringSliceVar(&opts.SurveyResourceGroups, "survey-resource-groups", nil, "Survey resource groups")

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -22,7 +22,6 @@ type regoFile struct {
 	ResourceType string
 	Description  string
 	Text         string
-	Severity     string
 }
 
 func (rego *regoFile) ParseText() error {
@@ -67,7 +66,6 @@ func (rego *regoFile) ParseText() error {
 	rego.Provider = getHeader("Provider")
 	rego.ResourceType = getHeader("Resource-Type")
 	rego.Description = getHeader("Description")
-	rego.Severity = getHeader("Severity")
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -22,6 +22,7 @@ type regoFile struct {
 	ResourceType string
 	Description  string
 	Text         string
+	Severity     string
 }
 
 func (rego *regoFile) ParseText() error {
@@ -66,6 +67,7 @@ func (rego *regoFile) ParseText() error {
 	rego.Provider = getHeader("Provider")
 	rego.ResourceType = getHeader("Resource-Type")
 	rego.Description = getHeader("Description")
+	rego.Severity = getHeader("Severity")
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {

--- a/models/create_environment_input.go
+++ b/models/create_environment_input.go
@@ -40,7 +40,7 @@ type CreateEnvironmentInput struct {
 	ScanInterval *int64 `json:"scan_interval,omitempty"`
 
 	// Indicates if the new environment should have scans run on a schedule upon creation.
-	ScanScheduleEnabled bool `json:"scan_schedule_enabled,omitempty"`
+	ScanScheduleEnabled *bool `json:"scan_schedule_enabled,omitempty"`
 
 	// List of resource types to be surveyed.
 	SurveyResourceTypes []string `json:"survey_resource_types"`

--- a/models/create_environment_input.go
+++ b/models/create_environment_input.go
@@ -37,7 +37,7 @@ type CreateEnvironmentInput struct {
 
 	// Time in seconds between the end of one scan to the start of the next. Must also set scan_schedule_enabled to true.
 	// Minimum: 300
-	ScanInterval int64 `json:"scan_interval,omitempty"`
+	ScanInterval *int64 `json:"scan_interval,omitempty"`
 
 	// Indicates if the new environment should have scans run on a schedule upon creation.
 	ScanScheduleEnabled bool `json:"scan_schedule_enabled,omitempty"`
@@ -138,7 +138,7 @@ func (m *CreateEnvironmentInput) validateScanInterval(formats strfmt.Registry) e
 		return nil
 	}
 
-	if err := validate.MinimumInt("scan_interval", "body", int64(m.ScanInterval), 300, false); err != nil {
+	if err := validate.MinimumInt("scan_interval", "body", int64(*m.ScanInterval), 300, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Due to `omitempty` property on the JSON marshaling, zeroed values are omitted from the JSON.  This caused `--scan-interval 0` to trigger the API to set `scan_interval` to the system default of 86400.  Changing both `ScanInterval` and `ScanScheduledEnabled` to pointers allows for sending of explicit `nil` values as well as zeroed values (i.e. `0` and `false`).  This allows users to turn off scheduled scans by setting scan interval to 0.