### PR TITLE
Add Support for Custom Rules Severity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ SOURCES=$(shell find . -name '*.go')
 GOPATH?=$(shell go env GOPATH)
 
 UPDATE_ENV_SRC=models/update_environment_input.go
-UPDATE_RULE_SRC=models/update_custom_rule_input.go
 
 GOSWAGGER=docker run --rm -it \
 	--volume $(shell pwd):/fugue-client \
@@ -48,7 +47,6 @@ gen: $(SWAGGER)
 	sed -i "" "s/BaselineID string/BaselineID *string/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/Remediation bool/Remediation *bool/g" $(UPDATE_ENV_SRC)
 	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_ENV_SRC)
-	sed -i "" "s/ScanScheduleEnabled bool/ScanScheduleEnabled *bool/g" $(UPDATE_RULE_SRC)
 
 .PHONY: test
 test:

--- a/cmd/createRule.go
+++ b/cmd/createRule.go
@@ -13,6 +13,7 @@ type createRuleOptions struct {
 	Name         string
 	Description  string
 	Provider     string
+	Severity     string
 	ResourceType string
 	RuleText     string
 }
@@ -34,6 +35,7 @@ func NewCreateRuleCommand() *cobra.Command {
 				Name:         opts.Name,
 				Description:  opts.Description,
 				ResourceType: opts.ResourceType,
+				Severity:     opts.Severity,
 				Provider:     opts.Provider,
 				RuleText:     opts.RuleText,
 			}
@@ -55,6 +57,7 @@ func NewCreateRuleCommand() *cobra.Command {
 				Item{"DESCRIPTION", rule.Description},
 				Item{"PROVIDER", rule.Provider},
 				Item{"RESOURCE_TYPE", rule.ResourceType},
+				Item{"SEVERIY", rule.Severity},
 				Item{"STATUS", rule.Status},
 			}
 
@@ -74,12 +77,14 @@ func NewCreateRuleCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Rule name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "Description")
 	cmd.Flags().StringVar(&opts.Provider, "provider", "", "Provider")
+	cmd.Flags().StringVar(&opts.Severity, "severity", "", "Severity")
 	cmd.Flags().StringVar(&opts.ResourceType, "resource-type", "", "Resource type")
 	cmd.Flags().StringVar(&opts.RuleText, "text", "", "Rule text")
 
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("description")
 	cmd.MarkFlagRequired("provider")
+	cmd.MarkFlagRequired("severity")
 	cmd.MarkFlagRequired("resource-type")
 	cmd.MarkFlagRequired("text")
 

--- a/cmd/createRule.go
+++ b/cmd/createRule.go
@@ -57,7 +57,7 @@ func NewCreateRuleCommand() *cobra.Command {
 				Item{"DESCRIPTION", rule.Description},
 				Item{"PROVIDER", rule.Provider},
 				Item{"RESOURCE_TYPE", rule.ResourceType},
-				Item{"SEVERIY", rule.Severity},
+				Item{"SEVERITY", rule.Severity},
 				Item{"STATUS", rule.Status},
 			}
 
@@ -84,7 +84,6 @@ func NewCreateRuleCommand() *cobra.Command {
 	cmd.MarkFlagRequired("name")
 	cmd.MarkFlagRequired("description")
 	cmd.MarkFlagRequired("provider")
-	cmd.MarkFlagRequired("severity")
 	cmd.MarkFlagRequired("resource-type")
 	cmd.MarkFlagRequired("text")
 

--- a/cmd/getRule.go
+++ b/cmd/getRule.go
@@ -42,6 +42,7 @@ func NewGetRuleCommand() *cobra.Command {
 				Item{"NAME", rule.Name},
 				Item{"DESCRIPTION", rule.Description},
 				Item{"PROVIDER", rule.Provider},
+				Item{"SEVERITY", rule.Severity},
 				Item{"RESOURCE_TYPE", rule.ResourceType},
 				Item{"STATUS", rule.Status},
 			}

--- a/cmd/listRules.go
+++ b/cmd/listRules.go
@@ -17,6 +17,7 @@ type listRulesViewItem struct {
 	Name         string
 	Description  string
 	Provider     string
+	Severity     string
 	ResourceType string
 	RuleText     string
 	Status       string
@@ -59,6 +60,7 @@ func NewListRulesCommand() *cobra.Command {
 					Name:         rule.Name,
 					Description:  description,
 					Provider:     rule.Provider,
+					Severity:	  rule.Severity,
 					ResourceType: rule.ResourceType,
 					RuleText:     rule.RuleText,
 					Status:       rule.Status,
@@ -86,6 +88,7 @@ func NewListRulesCommand() *cobra.Command {
 		"ID",
 		"Name",
 		"Provider",
+		"Severity",
 		"ResourceType",
 		"Status",
 		"Description",

--- a/cmd/listRules.go
+++ b/cmd/listRules.go
@@ -60,7 +60,7 @@ func NewListRulesCommand() *cobra.Command {
 					Name:         rule.Name,
 					Description:  description,
 					Provider:     rule.Provider,
-					Severity:	  rule.Severity,
+					Severity:     rule.Severity,
 					ResourceType: rule.ResourceType,
 					RuleText:     rule.RuleText,
 					Status:       rule.Status,

--- a/cmd/listScans.go
+++ b/cmd/listScans.go
@@ -100,7 +100,7 @@ func NewListScansCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&opts.MaxItems, "max-items", 20, "max items to return")
 	cmd.Flags().StringVar(&opts.OrderBy, "order-by", "", "order by attribute")
 	cmd.Flags().StringVar(&opts.OrderDirection, "order-direction", "", "order by direction [asc | desc]")
-	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Scan status filter [IN-PROGRESS | SUCCESS | ERROR]")
+	cmd.Flags().StringSliceVar(&opts.Status, "status", nil, "Scan status filter [IN_PROGRESS | SUCCESS | ERROR]")
 	cmd.Flags().Int64Var(&opts.RangeFrom, "range-from", 0, "Range from time filter")
 	cmd.Flags().Int64Var(&opts.RangeTo, "range-to", 0, "Range to time filter")
 

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -21,6 +21,7 @@ type regoFile struct {
 	Provider     string
 	ResourceType string
 	Description  string
+	Severity     string
 	Text         string
 }
 
@@ -66,6 +67,7 @@ func (rego *regoFile) ParseText() error {
 	rego.Provider = getHeader("Provider")
 	rego.ResourceType = getHeader("Resource-Type")
 	rego.Description = getHeader("Description")
+	rego.Severity = getHeader("Severity")
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {
@@ -76,6 +78,9 @@ func (rego *regoFile) ParseText() error {
 	}
 	if rego.Provider == "" {
 		return errors.New("expected a provider by the header \"Provider\"")
+	}
+	if rego.Severity == "" {
+		return errors.New("expected a severity by the header \"Severity\"")
 	}
 
 	return nil
@@ -155,6 +160,7 @@ func NewSyncRulesCommand() *cobra.Command {
 						Description:  rego.Description,
 						ResourceType: rego.ResourceType,
 						Provider:     rego.Provider,
+						Severity:     rego.Severity,
 						RuleText:     rego.Text,
 					}
 					client.CustomRules.CreateCustomRule(params, auth)
@@ -165,6 +171,7 @@ func NewSyncRulesCommand() *cobra.Command {
 					params.Rule = &models.UpdateCustomRuleInput{
 						Description:  rego.Description,
 						ResourceType: rego.ResourceType,
+						Severity:     rego.Severity,
 						RuleText:     rego.Text,
 					}
 					client.CustomRules.UpdateCustomRule(params, auth)

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -81,7 +81,6 @@ func (rego *regoFile) ParseText() error {
 	}
 	if rego.Severity == "" {
 		rego.Severity = "High"
-		return errors.New("expected a severity by the header \"Severity\" -- setting severity to default High")
 	}
 
 	return nil
@@ -145,10 +144,8 @@ func NewSyncRulesCommand() *cobra.Command {
 
 				rego, err := loadRego(path)
 				if err != nil {
-					fmt.Println("WARN:", err)
-					if !strings.Contains(err.Error(), "severity") {
-						return nil
-					}
+					CheckErr(err)
+					return nil
 				}
 				if rego == nil {
 					return nil

--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -80,7 +80,8 @@ func (rego *regoFile) ParseText() error {
 		return errors.New("expected a provider by the header \"Provider\"")
 	}
 	if rego.Severity == "" {
-		return errors.New("expected a severity by the header \"Severity\"")
+		rego.Severity = "High"
+		return errors.New("expected a severity by the header \"Severity\" -- setting severity to default High")
 	}
 
 	return nil
@@ -145,7 +146,9 @@ func NewSyncRulesCommand() *cobra.Command {
 				rego, err := loadRego(path)
 				if err != nil {
 					fmt.Println("WARN:", err)
-					return nil
+					if !strings.Contains(err.Error(), "severity") {
+						return nil
+					}
 				}
 				if rego == nil {
 					return nil

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -10,6 +10,7 @@ func TestParseRego(t *testing.T) {
 		rego        *regoFile
 		expProvider string
 		expResource string
+		expSeverity string
 	}{
 		{
 			"single-aws",
@@ -17,11 +18,13 @@ func TestParseRego(t *testing.T) {
 				Text: `
 # Provider: AWS
 # Resource-Type: AWS.EC2.Instance
+# Severity: Low
 # Description: fake
 deny{}`,
 			},
 			"AWS",
 			"AWS.EC2.Instance",
+			"Low",
 		},
 		{
 			"multiple-aws",
@@ -30,10 +33,12 @@ deny{}`,
 # Provider: AWS
 # Resource-Type: MULTIPLE
 # Description: fake
+# Severity: Medium
 deny{}`,
 			},
 			"AWS",
 			"MULTIPLE",
+			"Medium",
 		},
 		{
 			"single-aws-govcloud",
@@ -42,11 +47,12 @@ deny{}`,
 # Provider: AWS_GOVCLOUD
 # Resource-Type: AWS.EC2.Instance
 # Description: fake
-
+# Severity: High
 deny{}`,
 			},
 			"AWS_GOVCLOUD",
 			"AWS.EC2.Instance",
+			"High",
 		},
 		{
 			"multiple-aws-govcloud",
@@ -55,11 +61,12 @@ deny{}`,
 # Provider: AWS_GOVCLOUD
 # Resource-Type: MULTIPLE
 # Description: fake
-
+# Severity: Critical
 deny{}`,
 			},
 			"AWS_GOVCLOUD",
 			"MULTIPLE",
+			"Critical",
 		},
 		{
 			"single-azure",
@@ -68,10 +75,12 @@ deny{}`,
 # Provider: Azure
 # Resource-Type: Azure.Compute.VirtualMachine
 # Description: fake
+# Severity: Informational
 deny{}`,
 			},
 			"Azure",
 			"Azure.Compute.VirtualMachine",
+			"Informational",
 		},
 		{
 			"multiple-azure",
@@ -80,10 +89,12 @@ deny{}`,
 # Provider: Azure
 # Resource-Type: MULTIPLE
 # Description: fake
+# Severity: Low
 deny{}`,
 			},
 			"Azure",
 			"MULTIPLE",
+			"Low",
 		},
 		{
 			"becki1-aws-s3-bucket-sse",
@@ -92,13 +103,14 @@ deny{}`,
 # Provider: AWS_GOVCLOUD
 # Resource-Type: AWS.S3.Bucket
 # Description: SSE encryption should be enabled for S3 buckets (AES-256 or KMS).
-
+# Severity: Medium
 allow {
   input.server_side_encryption_configuration[_].rule[_][_][_].sse_algorithm = _
 }`,
 			},
 			"AWS_GOVCLOUD",
 			"AWS.S3.Bucket",
+			"Medium",
 		},
 	}
 

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -112,13 +113,26 @@ allow {
 			"AWS.S3.Bucket",
 			"Medium",
 		},
+		{
+			"single-aws-no-severity",
+			&regoFile{
+				Text: `
+# Provider: AWS
+# Resource-Type: AWS.EC2.Instance
+# Description: fake
+deny{}`,
+			},
+			"AWS",
+			"AWS.EC2.Instance",
+			"High",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.rego.ParseText()
 
-			if err != nil {
+			if err != nil && !strings.Contains(err.Error(), "severity") {
 				t.Errorf("Error in parseRego %s", err.Error())
 			}
 			if tt.rego.Provider != tt.expProvider {
@@ -126,6 +140,9 @@ allow {
 			}
 			if tt.rego.ResourceType != tt.expResource {
 				t.Errorf("Expected %s, actual %s", tt.expResource, tt.rego.ResourceType)
+			}
+			if tt.rego.Severity != tt.expSeverity {
+				t.Errorf("Expected %s, actual %s", tt.expSeverity, tt.rego.Severity)
 			}
 		})
 	}

--- a/cmd/syncRules_test.go
+++ b/cmd/syncRules_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -132,7 +131,7 @@ deny{}`,
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.rego.ParseText()
 
-			if err != nil && !strings.Contains(err.Error(), "severity") {
+			if err != nil {
 				t.Errorf("Error in parseRego %s", err.Error())
 			}
 			if tt.rego.Provider != tt.expProvider {

--- a/cmd/updateRule.go
+++ b/cmd/updateRule.go
@@ -16,6 +16,7 @@ type updateRuleOptions struct {
 	ID           string
 	Name         string
 	Description  string
+	Severity     string
 	ResourceType string
 	RuleText     string
 }
@@ -47,6 +48,8 @@ func NewUpdateRuleCommand() *cobra.Command {
 					params.Rule.Name = opts.Name
 				case "description":
 					params.Rule.Description = opts.Description
+				case "severity":
+					params.Rule.Severity = opts.Severity
 				case "resource-type":
 					params.Rule.ResourceType = opts.ResourceType
 				case "text":
@@ -67,6 +70,7 @@ func NewUpdateRuleCommand() *cobra.Command {
 				Item{"NAME", rule.Name},
 				Item{"DESCRIPTION", rule.Description},
 				Item{"PROVIDER", rule.Provider},
+				Item{"SEVERITY", rule.Severity},
 				Item{"RESOURCE_TYPE", rule.ResourceType},
 				Item{"STATUS", rule.Status},
 			}
@@ -86,6 +90,7 @@ func NewUpdateRuleCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Rule name")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "Description")
+	cmd.Flags().StringVar(&opts.Severity, "severity", "", "Severity")
 	cmd.Flags().StringVar(&opts.ResourceType, "resource-type", "", "Resource type")
 	cmd.Flags().StringVar(&opts.RuleText, "text", "", "Rule text")
 

--- a/models/create_custom_rule_input.go
+++ b/models/create_custom_rule_input.go
@@ -36,7 +36,7 @@ type CreateCustomRuleInput struct {
 	RuleText string `json:"rule_text,omitempty"`
 
 	// Severity level of the custom rule.
-	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	// Enum: [Informational Low Medium High Critical]
 	Severity string `json:"severity,omitempty"`
 
 	// The origin of this rule
@@ -116,7 +116,7 @@ var createCustomRuleInputTypeSeverityPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Informational","Low","Medium","High","Critical"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -126,20 +126,20 @@ func init() {
 
 const (
 
-	// CreateCustomRuleInputSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
-	CreateCustomRuleInputSeverityINFORMATIONAL string = "INFORMATIONAL"
+	// CreateCustomRuleInputSeverityInformational captures enum value "Informational"
+	CreateCustomRuleInputSeverityInformational string = "Informational"
 
-	// CreateCustomRuleInputSeverityLOW captures enum value "LOW"
-	CreateCustomRuleInputSeverityLOW string = "LOW"
+	// CreateCustomRuleInputSeverityLow captures enum value "Low"
+	CreateCustomRuleInputSeverityLow string = "Low"
 
-	// CreateCustomRuleInputSeverityMEDIUM captures enum value "MEDIUM"
-	CreateCustomRuleInputSeverityMEDIUM string = "MEDIUM"
+	// CreateCustomRuleInputSeverityMedium captures enum value "Medium"
+	CreateCustomRuleInputSeverityMedium string = "Medium"
 
-	// CreateCustomRuleInputSeverityHIGH captures enum value "HIGH"
-	CreateCustomRuleInputSeverityHIGH string = "HIGH"
+	// CreateCustomRuleInputSeverityHigh captures enum value "High"
+	CreateCustomRuleInputSeverityHigh string = "High"
 
-	// CreateCustomRuleInputSeverityCRITICAL captures enum value "CRITICAL"
-	CreateCustomRuleInputSeverityCRITICAL string = "CRITICAL"
+	// CreateCustomRuleInputSeverityCritical captures enum value "Critical"
+	CreateCustomRuleInputSeverityCritical string = "Critical"
 )
 
 // prop value enum

--- a/models/create_custom_rule_input.go
+++ b/models/create_custom_rule_input.go
@@ -35,6 +35,10 @@ type CreateCustomRuleInput struct {
 	// The rego source code for the rule
 	RuleText string `json:"rule_text,omitempty"`
 
+	// Severity level of the custom rule.
+	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	Severity string `json:"severity,omitempty"`
+
 	// The origin of this rule
 	// Enum: [FUGUE CUSTOM]
 	Source string `json:"source,omitempty"`
@@ -45,6 +49,10 @@ func (m *CreateCustomRuleInput) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateProvider(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSeverity(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -98,6 +106,58 @@ func (m *CreateCustomRuleInput) validateProvider(formats strfmt.Registry) error 
 
 	// value enum
 	if err := m.validateProviderEnum("provider", "body", m.Provider); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var createCustomRuleInputTypeSeverityPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		createCustomRuleInputTypeSeverityPropEnum = append(createCustomRuleInputTypeSeverityPropEnum, v)
+	}
+}
+
+const (
+
+	// CreateCustomRuleInputSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
+	CreateCustomRuleInputSeverityINFORMATIONAL string = "INFORMATIONAL"
+
+	// CreateCustomRuleInputSeverityLOW captures enum value "LOW"
+	CreateCustomRuleInputSeverityLOW string = "LOW"
+
+	// CreateCustomRuleInputSeverityMEDIUM captures enum value "MEDIUM"
+	CreateCustomRuleInputSeverityMEDIUM string = "MEDIUM"
+
+	// CreateCustomRuleInputSeverityHIGH captures enum value "HIGH"
+	CreateCustomRuleInputSeverityHIGH string = "HIGH"
+
+	// CreateCustomRuleInputSeverityCRITICAL captures enum value "CRITICAL"
+	CreateCustomRuleInputSeverityCRITICAL string = "CRITICAL"
+)
+
+// prop value enum
+func (m *CreateCustomRuleInput) validateSeverityEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, createCustomRuleInputTypeSeverityPropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *CreateCustomRuleInput) validateSeverity(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Severity) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateSeverityEnum("severity", "body", m.Severity); err != nil {
 		return err
 	}
 

--- a/models/custom_rule.go
+++ b/models/custom_rule.go
@@ -50,6 +50,10 @@ type CustomRule struct {
 	// The rego source code for the rule.
 	RuleText string `json:"rule_text,omitempty"`
 
+	// Severity level of the custom rule.
+	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	Severity string `json:"severity,omitempty"`
+
 	// The origin of this rule.
 	// Enum: [CUSTOM]
 	Source string `json:"source,omitempty"`
@@ -73,6 +77,10 @@ func (m *CustomRule) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateProvider(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateSeverity(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -130,6 +138,58 @@ func (m *CustomRule) validateProvider(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateProviderEnum("provider", "body", m.Provider); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var customRuleTypeSeverityPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		customRuleTypeSeverityPropEnum = append(customRuleTypeSeverityPropEnum, v)
+	}
+}
+
+const (
+
+	// CustomRuleSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
+	CustomRuleSeverityINFORMATIONAL string = "INFORMATIONAL"
+
+	// CustomRuleSeverityLOW captures enum value "LOW"
+	CustomRuleSeverityLOW string = "LOW"
+
+	// CustomRuleSeverityMEDIUM captures enum value "MEDIUM"
+	CustomRuleSeverityMEDIUM string = "MEDIUM"
+
+	// CustomRuleSeverityHIGH captures enum value "HIGH"
+	CustomRuleSeverityHIGH string = "HIGH"
+
+	// CustomRuleSeverityCRITICAL captures enum value "CRITICAL"
+	CustomRuleSeverityCRITICAL string = "CRITICAL"
+)
+
+// prop value enum
+func (m *CustomRule) validateSeverityEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, customRuleTypeSeverityPropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *CustomRule) validateSeverity(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Severity) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateSeverityEnum("severity", "body", m.Severity); err != nil {
 		return err
 	}
 

--- a/models/custom_rule.go
+++ b/models/custom_rule.go
@@ -51,7 +51,7 @@ type CustomRule struct {
 	RuleText string `json:"rule_text,omitempty"`
 
 	// Severity level of the custom rule.
-	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	// Enum: [Informational Low Medium High Critical]
 	Severity string `json:"severity,omitempty"`
 
 	// The origin of this rule.
@@ -148,7 +148,7 @@ var customRuleTypeSeverityPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Informational","Low","Medium","High","Critical"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -158,20 +158,20 @@ func init() {
 
 const (
 
-	// CustomRuleSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
-	CustomRuleSeverityINFORMATIONAL string = "INFORMATIONAL"
+	// CustomRuleSeverityInformational captures enum value "Informational"
+	CustomRuleSeverityInformational string = "Informational"
 
-	// CustomRuleSeverityLOW captures enum value "LOW"
-	CustomRuleSeverityLOW string = "LOW"
+	// CustomRuleSeverityLow captures enum value "Low"
+	CustomRuleSeverityLow string = "Low"
 
-	// CustomRuleSeverityMEDIUM captures enum value "MEDIUM"
-	CustomRuleSeverityMEDIUM string = "MEDIUM"
+	// CustomRuleSeverityMedium captures enum value "Medium"
+	CustomRuleSeverityMedium string = "Medium"
 
-	// CustomRuleSeverityHIGH captures enum value "HIGH"
-	CustomRuleSeverityHIGH string = "HIGH"
+	// CustomRuleSeverityHigh captures enum value "High"
+	CustomRuleSeverityHigh string = "High"
 
-	// CustomRuleSeverityCRITICAL captures enum value "CRITICAL"
-	CustomRuleSeverityCRITICAL string = "CRITICAL"
+	// CustomRuleSeverityCritical captures enum value "Critical"
+	CustomRuleSeverityCritical string = "Critical"
 )
 
 // prop value enum

--- a/models/update_custom_rule_input.go
+++ b/models/update_custom_rule_input.go
@@ -32,7 +32,7 @@ type UpdateCustomRuleInput struct {
 	RuleText string `json:"rule_text,omitempty"`
 
 	// Severity level of the custom rule.
-	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	// Enum: [Informational Low Medium High Critical]
 	Severity string `json:"severity,omitempty"`
 
 	// Status of the custom rule
@@ -62,7 +62,7 @@ var updateCustomRuleInputTypeSeverityPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["Informational","Low","Medium","High","Critical"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -72,20 +72,20 @@ func init() {
 
 const (
 
-	// UpdateCustomRuleInputSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
-	UpdateCustomRuleInputSeverityINFORMATIONAL string = "INFORMATIONAL"
+	// UpdateCustomRuleInputSeverityInformational captures enum value "Informational"
+	UpdateCustomRuleInputSeverityInformational string = "Informational"
 
-	// UpdateCustomRuleInputSeverityLOW captures enum value "LOW"
-	UpdateCustomRuleInputSeverityLOW string = "LOW"
+	// UpdateCustomRuleInputSeverityLow captures enum value "Low"
+	UpdateCustomRuleInputSeverityLow string = "Low"
 
-	// UpdateCustomRuleInputSeverityMEDIUM captures enum value "MEDIUM"
-	UpdateCustomRuleInputSeverityMEDIUM string = "MEDIUM"
+	// UpdateCustomRuleInputSeverityMedium captures enum value "Medium"
+	UpdateCustomRuleInputSeverityMedium string = "Medium"
 
-	// UpdateCustomRuleInputSeverityHIGH captures enum value "HIGH"
-	UpdateCustomRuleInputSeverityHIGH string = "HIGH"
+	// UpdateCustomRuleInputSeverityHigh captures enum value "High"
+	UpdateCustomRuleInputSeverityHigh string = "High"
 
-	// UpdateCustomRuleInputSeverityCRITICAL captures enum value "CRITICAL"
-	UpdateCustomRuleInputSeverityCRITICAL string = "CRITICAL"
+	// UpdateCustomRuleInputSeverityCritical captures enum value "Critical"
+	UpdateCustomRuleInputSeverityCritical string = "Critical"
 )
 
 // prop value enum

--- a/models/update_custom_rule_input.go
+++ b/models/update_custom_rule_input.go
@@ -31,6 +31,10 @@ type UpdateCustomRuleInput struct {
 	// Rego code used by the rule
 	RuleText string `json:"rule_text,omitempty"`
 
+	// Severity level of the custom rule.
+	// Enum: [INFORMATIONAL LOW MEDIUM HIGH CRITICAL]
+	Severity string `json:"severity,omitempty"`
+
 	// Status of the custom rule
 	// Enum: [ENABLED DISABLED]
 	Status string `json:"status,omitempty"`
@@ -40,6 +44,10 @@ type UpdateCustomRuleInput struct {
 func (m *UpdateCustomRuleInput) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateSeverity(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -47,6 +55,58 @@ func (m *UpdateCustomRuleInput) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+var updateCustomRuleInputTypeSeverityPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["INFORMATIONAL","LOW","MEDIUM","HIGH","CRITICAL"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		updateCustomRuleInputTypeSeverityPropEnum = append(updateCustomRuleInputTypeSeverityPropEnum, v)
+	}
+}
+
+const (
+
+	// UpdateCustomRuleInputSeverityINFORMATIONAL captures enum value "INFORMATIONAL"
+	UpdateCustomRuleInputSeverityINFORMATIONAL string = "INFORMATIONAL"
+
+	// UpdateCustomRuleInputSeverityLOW captures enum value "LOW"
+	UpdateCustomRuleInputSeverityLOW string = "LOW"
+
+	// UpdateCustomRuleInputSeverityMEDIUM captures enum value "MEDIUM"
+	UpdateCustomRuleInputSeverityMEDIUM string = "MEDIUM"
+
+	// UpdateCustomRuleInputSeverityHIGH captures enum value "HIGH"
+	UpdateCustomRuleInputSeverityHIGH string = "HIGH"
+
+	// UpdateCustomRuleInputSeverityCRITICAL captures enum value "CRITICAL"
+	UpdateCustomRuleInputSeverityCRITICAL string = "CRITICAL"
+)
+
+// prop value enum
+func (m *UpdateCustomRuleInput) validateSeverityEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, updateCustomRuleInputTypeSeverityPropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *UpdateCustomRuleInput) validateSeverity(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.Severity) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateSeverityEnum("severity", "body", m.Severity); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This adds `severity` to Custom Rules models and all related commands.  This includes adding support for `# Severity: <severity>` as a header in rego files when using the `sync` command.  

This PR also includes a little cleaning up including:
* removing unnecessary Make target and `sed` command from Makefile
* changing help text in `list scans` for `status` to `IN_PROGRESS`

This PR should not be merged until custom rules severity support has been added to the Fugue API.