### PR TITLE
Add Missing 400 Responses

### DIFF
--- a/client/custom_rules/delete_custom_rule_responses.go
+++ b/client/custom_rules/delete_custom_rule_responses.go
@@ -29,6 +29,12 @@ func (o *DeleteCustomRuleReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewDeleteCustomRuleBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewDeleteCustomRuleUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -70,6 +76,39 @@ func (o *DeleteCustomRuleNoContent) Error() string {
 }
 
 func (o *DeleteCustomRuleNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteCustomRuleBadRequest creates a DeleteCustomRuleBadRequest with default headers values
+func NewDeleteCustomRuleBadRequest() *DeleteCustomRuleBadRequest {
+	return &DeleteCustomRuleBadRequest{}
+}
+
+/*DeleteCustomRuleBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type DeleteCustomRuleBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *DeleteCustomRuleBadRequest) Error() string {
+	return fmt.Sprintf("[DELETE /rules/{rule_id}][%d] deleteCustomRuleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *DeleteCustomRuleBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *DeleteCustomRuleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/custom_rules/list_custom_rules_responses.go
+++ b/client/custom_rules/list_custom_rules_responses.go
@@ -29,6 +29,12 @@ func (o *ListCustomRulesReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewListCustomRulesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewListCustomRulesUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -77,6 +83,39 @@ func (o *ListCustomRulesOK) GetPayload() *models.CustomRules {
 func (o *ListCustomRulesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.CustomRules)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewListCustomRulesBadRequest creates a ListCustomRulesBadRequest with default headers values
+func NewListCustomRulesBadRequest() *ListCustomRulesBadRequest {
+	return &ListCustomRulesBadRequest{}
+}
+
+/*ListCustomRulesBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type ListCustomRulesBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *ListCustomRulesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /rules][%d] listCustomRulesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *ListCustomRulesBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *ListCustomRulesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/custom_rules/test_custom_rule_input_responses.go
+++ b/client/custom_rules/test_custom_rule_input_responses.go
@@ -29,6 +29,12 @@ func (o *TestCustomRuleInputReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewTestCustomRuleInputBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewTestCustomRuleInputUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -77,6 +83,39 @@ func (o *TestCustomRuleInputOK) GetPayload() *models.TestCustomRuleInputScan {
 func (o *TestCustomRuleInputOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.TestCustomRuleInputScan)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewTestCustomRuleInputBadRequest creates a TestCustomRuleInputBadRequest with default headers values
+func NewTestCustomRuleInputBadRequest() *TestCustomRuleInputBadRequest {
+	return &TestCustomRuleInputBadRequest{}
+}
+
+/*TestCustomRuleInputBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type TestCustomRuleInputBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *TestCustomRuleInputBadRequest) Error() string {
+	return fmt.Sprintf("[GET /rules/test/input][%d] testCustomRuleInputBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *TestCustomRuleInputBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *TestCustomRuleInputBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/custom_rules/test_custom_rule_responses.go
+++ b/client/custom_rules/test_custom_rule_responses.go
@@ -29,6 +29,12 @@ func (o *TestCustomRuleReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewTestCustomRuleBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewTestCustomRuleUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -77,6 +83,39 @@ func (o *TestCustomRuleOK) GetPayload() *models.TestCustomRuleOutput {
 func (o *TestCustomRuleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.TestCustomRuleOutput)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewTestCustomRuleBadRequest creates a TestCustomRuleBadRequest with default headers values
+func NewTestCustomRuleBadRequest() *TestCustomRuleBadRequest {
+	return &TestCustomRuleBadRequest{}
+}
+
+/*TestCustomRuleBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type TestCustomRuleBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *TestCustomRuleBadRequest) Error() string {
+	return fmt.Sprintf("[POST /rules/test][%d] testCustomRuleBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *TestCustomRuleBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *TestCustomRuleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/environments/create_environment_responses.go
+++ b/client/environments/create_environment_responses.go
@@ -29,6 +29,12 @@ func (o *CreateEnvironmentReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewCreateEnvironmentBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewCreateEnvironmentUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *CreateEnvironmentCreated) GetPayload() *models.Environment {
 func (o *CreateEnvironmentCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Environment)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateEnvironmentBadRequest creates a CreateEnvironmentBadRequest with default headers values
+func NewCreateEnvironmentBadRequest() *CreateEnvironmentBadRequest {
+	return &CreateEnvironmentBadRequest{}
+}
+
+/*CreateEnvironmentBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type CreateEnvironmentBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *CreateEnvironmentBadRequest) Error() string {
+	return fmt.Sprintf("[POST /environments][%d] createEnvironmentBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *CreateEnvironmentBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *CreateEnvironmentBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/environments/delete_environment_responses.go
+++ b/client/environments/delete_environment_responses.go
@@ -29,6 +29,12 @@ func (o *DeleteEnvironmentReader) ReadResponse(response runtime.ClientResponse, 
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewDeleteEnvironmentBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewDeleteEnvironmentUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -76,6 +82,39 @@ func (o *DeleteEnvironmentNoContent) Error() string {
 }
 
 func (o *DeleteEnvironmentNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteEnvironmentBadRequest creates a DeleteEnvironmentBadRequest with default headers values
+func NewDeleteEnvironmentBadRequest() *DeleteEnvironmentBadRequest {
+	return &DeleteEnvironmentBadRequest{}
+}
+
+/*DeleteEnvironmentBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type DeleteEnvironmentBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *DeleteEnvironmentBadRequest) Error() string {
+	return fmt.Sprintf("[DELETE /environments/{environment_id}][%d] deleteEnvironmentBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *DeleteEnvironmentBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *DeleteEnvironmentBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/environments/get_environment_responses.go
+++ b/client/environments/get_environment_responses.go
@@ -29,6 +29,12 @@ func (o *GetEnvironmentReader) ReadResponse(response runtime.ClientResponse, con
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewGetEnvironmentBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewGetEnvironmentUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *GetEnvironmentOK) GetPayload() *models.EnvironmentWithSummary {
 func (o *GetEnvironmentOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.EnvironmentWithSummary)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetEnvironmentBadRequest creates a GetEnvironmentBadRequest with default headers values
+func NewGetEnvironmentBadRequest() *GetEnvironmentBadRequest {
+	return &GetEnvironmentBadRequest{}
+}
+
+/*GetEnvironmentBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type GetEnvironmentBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *GetEnvironmentBadRequest) Error() string {
+	return fmt.Sprintf("[GET /environments/{environment_id}][%d] getEnvironmentBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetEnvironmentBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *GetEnvironmentBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/events/list_events_responses.go
+++ b/client/events/list_events_responses.go
@@ -29,6 +29,12 @@ func (o *ListEventsReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewListEventsBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewListEventsUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *ListEventsOK) GetPayload() *models.Events {
 func (o *ListEventsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Events)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewListEventsBadRequest creates a ListEventsBadRequest with default headers values
+func NewListEventsBadRequest() *ListEventsBadRequest {
+	return &ListEventsBadRequest{}
+}
+
+/*ListEventsBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type ListEventsBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *ListEventsBadRequest) Error() string {
+	return fmt.Sprintf("[GET /events][%d] listEventsBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *ListEventsBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *ListEventsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/notifications/create_notification_responses.go
+++ b/client/notifications/create_notification_responses.go
@@ -29,6 +29,12 @@ func (o *CreateNotificationReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewCreateNotificationBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewCreateNotificationUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *CreateNotificationCreated) GetPayload() *models.Notification {
 func (o *CreateNotificationCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Notification)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateNotificationBadRequest creates a CreateNotificationBadRequest with default headers values
+func NewCreateNotificationBadRequest() *CreateNotificationBadRequest {
+	return &CreateNotificationBadRequest{}
+}
+
+/*CreateNotificationBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type CreateNotificationBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *CreateNotificationBadRequest) Error() string {
+	return fmt.Sprintf("[POST /notifications][%d] createNotificationBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *CreateNotificationBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *CreateNotificationBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/notifications/delete_notification_responses.go
+++ b/client/notifications/delete_notification_responses.go
@@ -29,6 +29,12 @@ func (o *DeleteNotificationReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewDeleteNotificationBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewDeleteNotificationUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -76,6 +82,39 @@ func (o *DeleteNotificationNoContent) Error() string {
 }
 
 func (o *DeleteNotificationNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewDeleteNotificationBadRequest creates a DeleteNotificationBadRequest with default headers values
+func NewDeleteNotificationBadRequest() *DeleteNotificationBadRequest {
+	return &DeleteNotificationBadRequest{}
+}
+
+/*DeleteNotificationBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type DeleteNotificationBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *DeleteNotificationBadRequest) Error() string {
+	return fmt.Sprintf("[DELETE /notifications/{notification_id}][%d] deleteNotificationBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *DeleteNotificationBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *DeleteNotificationBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/notifications/update_notification_responses.go
+++ b/client/notifications/update_notification_responses.go
@@ -29,6 +29,12 @@ func (o *UpdateNotificationReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewUpdateNotificationBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewUpdateNotificationUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *UpdateNotificationOK) GetPayload() *models.Notification {
 func (o *UpdateNotificationOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.Notification)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewUpdateNotificationBadRequest creates a UpdateNotificationBadRequest with default headers values
+func NewUpdateNotificationBadRequest() *UpdateNotificationBadRequest {
+	return &UpdateNotificationBadRequest{}
+}
+
+/*UpdateNotificationBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type UpdateNotificationBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *UpdateNotificationBadRequest) Error() string {
+	return fmt.Sprintf("[PUT /notifications/{notification_id}][%d] updateNotificationBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *UpdateNotificationBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *UpdateNotificationBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/scans/get_compliance_by_resource_types_responses.go
+++ b/client/scans/get_compliance_by_resource_types_responses.go
@@ -29,6 +29,12 @@ func (o *GetComplianceByResourceTypesReader) ReadResponse(response runtime.Clien
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewGetComplianceByResourceTypesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewGetComplianceByResourceTypesUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *GetComplianceByResourceTypesOK) GetPayload() *models.ComplianceByResour
 func (o *GetComplianceByResourceTypesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ComplianceByResourceTypeOutput)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetComplianceByResourceTypesBadRequest creates a GetComplianceByResourceTypesBadRequest with default headers values
+func NewGetComplianceByResourceTypesBadRequest() *GetComplianceByResourceTypesBadRequest {
+	return &GetComplianceByResourceTypesBadRequest{}
+}
+
+/*GetComplianceByResourceTypesBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type GetComplianceByResourceTypesBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *GetComplianceByResourceTypesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /scans/{scan_id}/compliance_by_resource_types][%d] getComplianceByResourceTypesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetComplianceByResourceTypesBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *GetComplianceByResourceTypesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/scans/get_compliance_by_rules_responses.go
+++ b/client/scans/get_compliance_by_rules_responses.go
@@ -29,6 +29,12 @@ func (o *GetComplianceByRulesReader) ReadResponse(response runtime.ClientRespons
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewGetComplianceByRulesBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewGetComplianceByRulesUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *GetComplianceByRulesOK) GetPayload() *models.ComplianceByRules {
 func (o *GetComplianceByRulesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ComplianceByRules)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetComplianceByRulesBadRequest creates a GetComplianceByRulesBadRequest with default headers values
+func NewGetComplianceByRulesBadRequest() *GetComplianceByRulesBadRequest {
+	return &GetComplianceByRulesBadRequest{}
+}
+
+/*GetComplianceByRulesBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type GetComplianceByRulesBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *GetComplianceByRulesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /scans/{scan_id}/compliance_by_rules][%d] getComplianceByRulesBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetComplianceByRulesBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *GetComplianceByRulesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/client/scans/get_scan_responses.go
+++ b/client/scans/get_scan_responses.go
@@ -29,6 +29,12 @@ func (o *GetScanReader) ReadResponse(response runtime.ClientResponse, consumer r
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewGetScanBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 401:
 		result := NewGetScanUnauthorized()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -83,6 +89,39 @@ func (o *GetScanOK) GetPayload() *models.ScanWithSummary {
 func (o *GetScanOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ScanWithSummary)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetScanBadRequest creates a GetScanBadRequest with default headers values
+func NewGetScanBadRequest() *GetScanBadRequest {
+	return &GetScanBadRequest{}
+}
+
+/*GetScanBadRequest handles this case with default header values.
+
+Bad request error.
+*/
+type GetScanBadRequest struct {
+	Payload *models.BadRequestError
+}
+
+func (o *GetScanBadRequest) Error() string {
+	return fmt.Sprintf("[GET /scans/{scan_id}][%d] getScanBadRequest  %+v", 400, o.Payload)
+}
+
+func (o *GetScanBadRequest) GetPayload() *models.BadRequestError {
+	return o.Payload
+}
+
+func (o *GetScanBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.BadRequestError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {


### PR DESCRIPTION
Some endpoints are missing a definition for `400` status responses.  This updates the swagger client with those response types.