### PR TITLE
Add `test` subcommand for testing custom rules

### DIFF
--- a/client/custom_rules/test_custom_rule_input_parameters.go
+++ b/client/custom_rules/test_custom_rule_input_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewTestCustomRuleInputParams creates a new TestCustomRuleInputParams object
@@ -65,6 +66,11 @@ type TestCustomRuleInputParams struct {
 
 	*/
 	ScanID string
+	/*ViaDownload
+	  Force output to be downloadable.
+
+	*/
+	ViaDownload *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -115,6 +121,17 @@ func (o *TestCustomRuleInputParams) SetScanID(scanID string) {
 	o.ScanID = scanID
 }
 
+// WithViaDownload adds the viaDownload to the test custom rule input params
+func (o *TestCustomRuleInputParams) WithViaDownload(viaDownload *bool) *TestCustomRuleInputParams {
+	o.SetViaDownload(viaDownload)
+	return o
+}
+
+// SetViaDownload adds the viaDownload to the test custom rule input params
+func (o *TestCustomRuleInputParams) SetViaDownload(viaDownload *bool) {
+	o.ViaDownload = viaDownload
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *TestCustomRuleInputParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -130,6 +147,22 @@ func (o *TestCustomRuleInputParams) WriteToRequest(r runtime.ClientRequest, reg 
 		if err := r.SetQueryParam("scan_id", qScanID); err != nil {
 			return err
 		}
+	}
+
+	if o.ViaDownload != nil {
+
+		// query param via_download
+		var qrViaDownload bool
+		if o.ViaDownload != nil {
+			qrViaDownload = *o.ViaDownload
+		}
+		qViaDownload := swag.FormatBool(qrViaDownload)
+		if qViaDownload != "" {
+			if err := r.SetQueryParam("via_download", qViaDownload); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/client/custom_rules/test_custom_rule_parameters.go
+++ b/client/custom_rules/test_custom_rule_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 
 	"github.com/fugue/fugue-client/models"
 )
@@ -67,6 +68,11 @@ type TestCustomRuleParams struct {
 
 	*/
 	Rule *models.TestCustomRuleInput
+	/*ViaDownload
+	  Force output to be downloadable.
+
+	*/
+	ViaDownload *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -117,6 +123,17 @@ func (o *TestCustomRuleParams) SetRule(rule *models.TestCustomRuleInput) {
 	o.Rule = rule
 }
 
+// WithViaDownload adds the viaDownload to the test custom rule params
+func (o *TestCustomRuleParams) WithViaDownload(viaDownload *bool) *TestCustomRuleParams {
+	o.SetViaDownload(viaDownload)
+	return o
+}
+
+// SetViaDownload adds the viaDownload to the test custom rule params
+func (o *TestCustomRuleParams) SetViaDownload(viaDownload *bool) {
+	o.ViaDownload = viaDownload
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *TestCustomRuleParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -129,6 +146,22 @@ func (o *TestCustomRuleParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		if err := r.SetBodyParam(o.Rule); err != nil {
 			return err
 		}
+	}
+
+	if o.ViaDownload != nil {
+
+		// query param via_download
+		var qrViaDownload bool
+		if o.ViaDownload != nil {
+			qrViaDownload = *o.ViaDownload
+		}
+		qViaDownload := swag.FormatBool(qrViaDownload)
+		if qViaDownload != "" {
+			if err := r.SetQueryParam("via_download", qViaDownload); err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if len(res) > 0 {

--- a/client/fugue_client.go
+++ b/client/fugue_client.go
@@ -10,7 +10,6 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/fugue/fugue-client/client/c_o_r_s"
 	"github.com/fugue/fugue-client/client/custom_rules"
 	"github.com/fugue/fugue-client/client/environments"
 	"github.com/fugue/fugue-client/client/events"

--- a/client/fugue_client.go
+++ b/client/fugue_client.go
@@ -60,7 +60,6 @@ func New(transport runtime.ClientTransport, formats strfmt.Registry) *Fugue {
 
 	cli := new(Fugue)
 	cli.Transport = transport
-	cli.Cors = c_o_r_s.New(transport, formats)
 	cli.CustomRules = custom_rules.New(transport, formats)
 	cli.Environments = environments.New(transport, formats)
 	cli.Events = events.New(transport, formats)
@@ -111,8 +110,6 @@ func (cfg *TransportConfig) WithSchemes(schemes []string) *TransportConfig {
 
 // Fugue is a client for fugue
 type Fugue struct {
-	Cors c_o_r_s.ClientService
-
 	CustomRules custom_rules.ClientService
 
 	Environments environments.ClientService
@@ -131,7 +128,6 @@ type Fugue struct {
 // SetTransport changes the transport on the client and all its subresources
 func (c *Fugue) SetTransport(transport runtime.ClientTransport) {
 	c.Transport = transport
-	c.Cors.SetTransport(transport)
 	c.CustomRules.SetTransport(transport)
 	c.Environments.SetTransport(transport)
 	c.Events.SetTransport(transport)

--- a/cmd/getRuleInput.go
+++ b/cmd/getRuleInput.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/fugue/fugue-client/client/custom_rules"
+	"github.com/spf13/cobra"
+)
+
+type getRuleInputOptions struct {
+	ScanID string
+}
+
+func getRuleInput(opts testRuleOptions) error {
+	client, auth := getClient()
+
+	viaDownload := true
+	params := custom_rules.NewTestCustomRuleInputParams()
+	params.ScanID = opts.ScanID
+	params.ViaDownload = &viaDownload
+
+	resp, err := client.CustomRules.TestCustomRuleInput(params, auth)
+	if err != nil {
+		return err
+	}
+
+	downloadResult, err := getDownloadResult(resp.Payload.Links)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := json.MarshalIndent(downloadResult.Input, "", "    ")
+	if err != nil {
+		return err
+	}
+	os.Stdout.Write(bytes)
+	fmt.Println("") // Add final newline after JSON.
+	return nil
+}
+
+func NewGetRuleInputCommand() *cobra.Command {
+	var opts testRuleOptions
+
+	cmd := &cobra.Command{
+		Use:   "rule-input",
+		Short: "Retrieve rule input",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			CheckErr(getRuleInput(opts))
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ScanID, "scan", "", "Scan ID")
+	cmd.MarkFlagRequired("scan")
+
+	return cmd
+}
+
+func init() {
+	getCmd.AddCommand(NewGetRuleInputCommand())
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test custom rules",
+}
+
+func init() {
+	rootCmd.AddCommand(testCmd)
+}

--- a/cmd/testRule.go
+++ b/cmd/testRule.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/fugue/fugue-client/client/custom_rules"
 	"github.com/fugue/fugue-client/format"
@@ -13,6 +15,7 @@ import (
 type testRuleOptions struct {
 	ScanID       string
 	ResourceType string
+	Input        bool
 }
 
 type testRuleResource struct {
@@ -21,71 +24,111 @@ type testRuleResource struct {
 	Type   string
 }
 
+// testRule does the actual work of testing the rule.  The command will delegate
+// to either this or `getRuleInput`.
+func testRule(opts testRuleOptions, regoFile string) error {
+	client, auth := getClient()
+
+	regoBytes, err := ioutil.ReadFile(regoFile)
+	if err != nil {
+		return err
+	}
+	regoText := string(regoBytes)
+
+	params := custom_rules.NewTestCustomRuleParams()
+	params.Rule = &models.TestCustomRuleInput{
+		ScanID:       &opts.ScanID,
+		ResourceType: opts.ResourceType,
+		RuleText:     &regoText,
+	}
+
+	resp, err := client.CustomRules.TestCustomRule(params, auth)
+	if err != nil {
+		return err
+	}
+
+	testOutput := resp.Payload
+	if len(testOutput.Errors) > 0 {
+		for _, regoError := range testOutput.Errors {
+			fmt.Println(regoError.Text)
+		}
+		return nil
+	}
+
+	var rows []interface{}
+	for _, resource := range testOutput.Resources {
+		rows = append(rows, testRuleResource{
+			ID:     resource.ID,
+			Result: resource.Result,
+			Type:   resource.Type,
+		})
+	}
+
+	table, err := format.Table(format.TableOpts{
+		Rows:       rows,
+		Columns:    []string{"ID", "Result", "Type"},
+		ShowHeader: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, tableRow := range table {
+		fmt.Println(tableRow)
+	}
+	return nil
+}
+
+// getRuleInput retrieves the rule input rather than running the rule.
+func getRuleInput(opts testRuleOptions) error {
+	client, auth := getClient()
+
+	params := custom_rules.NewTestCustomRuleInputParams()
+	params.ScanID = opts.ScanID
+
+	resp, err := client.CustomRules.TestCustomRuleInput(params, auth)
+	if err != nil {
+		return err
+	}
+
+	// TODO: we need to take the new `links` feature into account here.
+	bytes, err := json.MarshalIndent(resp.Payload, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	os.Stdout.Write(bytes)
+	fmt.Println("") // Add final newline after JSON.
+	return nil
+}
+
 func NewTestRuleCommand() *cobra.Command {
 	var opts testRuleOptions
 
 	cmd := &cobra.Command{
 		Use:   "rule [rego file]",
 		Short: "Test a custom rule",
-		Args:  cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if opts.Input {
+				return cobra.ExactArgs(0)(cmd, args)
+			} else {
+				return cobra.ExactArgs(1)(cmd, args)
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
-
-			client, auth := getClient()
-
-			regoFile := args[0]
-			regoBytes, err := ioutil.ReadFile(regoFile)
-			if err != nil {
-				CheckErr(err)
-			}
-			regoText := string(regoBytes)
-
-			params := custom_rules.NewTestCustomRuleParams()
-			params.Rule = &models.TestCustomRuleInput{
-				ScanID:       &opts.ScanID,
-				ResourceType: opts.ResourceType,
-				RuleText:     &regoText,
-			}
-
-			resp, err := client.CustomRules.TestCustomRule(params, auth)
-			if err != nil {
-				CheckErr(err)
-			}
-
-			testOutput := resp.Payload
-			if len(testOutput.Errors) > 0 {
-				for _, regoError := range testOutput.Errors {
-					fmt.Println(regoError.Text)
-				}
-				return
-			}
-
-			var rows []interface{}
-			for _, resource := range testOutput.Resources {
-				rows = append(rows, testRuleResource{
-					ID:     resource.ID,
-					Result: resource.Result,
-					Type:   resource.Type,
-				})
-			}
-
-			table, err := format.Table(format.TableOpts{
-				Rows:       rows,
-				Columns:    []string{"ID", "Result", "Type"},
-				ShowHeader: true,
-			})
-			CheckErr(err)
-
-			for _, tableRow := range table {
-				fmt.Println(tableRow)
+			if opts.Input {
+				CheckErr(getRuleInput(opts))
+			} else {
+				CheckErr(testRule(opts, args[0]))
 			}
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.ScanID, "scan", "", "Scan ID")
 	cmd.Flags().StringVar(&opts.ResourceType, "resource-type", "", "Resource type")
+	cmd.Flags().BoolVar(&opts.Input, "input", false, "Retrieve rule input")
 
 	cmd.MarkFlagRequired("scan")
-	cmd.MarkFlagRequired("resource-type")
 
 	return cmd
 }

--- a/cmd/testRule.go
+++ b/cmd/testRule.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 
 	"github.com/fugue/fugue-client/client/custom_rules"
@@ -48,6 +49,29 @@ func testRule(opts testRuleOptions, regoFile string) error {
 	}
 
 	testOutput := resp.Payload
+	if url, ok := testOutput.Links["output"]; ok {
+		// Download temporary file and perform conversions.
+		if tmpResult, err := getTmpResult(url); err == nil {
+			testOutput.Errors = make([]*models.CustomRuleError, 0)
+			for _, tmpError := range tmpResult.Errors {
+				testOutput.Errors = append(testOutput.Errors, fromTmpError(tmpError))
+			}
+			if tmpResult.Report != nil {
+				testOutput.Resources = make([]*models.TestCustomRuleOutputResource, 0)
+				for _, tmpResource := range tmpResult.Report.Resources {
+					testOutput.Resources = append(testOutput.Resources, fromTmpResource(tmpResource))
+				}
+			}
+		} else {
+			return err
+		}
+	}
+
+	// Check if we need to do a trip through `links["output"]`.
+	// if url, ok := resp.Payload.Links["output"]; ok {
+	// result, err := getTmpResult(url)
+	// }
+
 	if len(testOutput.Errors) > 0 {
 		for _, regoError := range testOutput.Errors {
 			fmt.Println(regoError.Text)
@@ -91,15 +115,86 @@ func getRuleInput(opts testRuleOptions) error {
 		return err
 	}
 
-	// TODO: we need to take the new `links` feature into account here.
+	if url, ok := resp.Payload.Links["output"]; ok {
+		// If the response is too big, it is provided as a download link.
+		if downloadResult, err := getTmpResult(url); err == nil {
+			resp.Payload = downloadResult.Input
+		} else {
+			return err
+		}
+	}
+
 	bytes, err := json.MarshalIndent(resp.Payload, "", "    ")
 	if err != nil {
 		return err
 	}
-
 	os.Stdout.Write(bytes)
 	fmt.Println("") // Add final newline after JSON.
 	return nil
+}
+
+// tmpResult describes the scheme that we download from the
+// `links["output"]` key, which is slightly different than what we usually
+// expect, so we need to do some conversions here.
+type tmpResult struct {
+	Input  *models.TestCustomRuleInputScan `json:"input,omitempty"`
+	Errors []*tmpError                     `json:"errors,omitempty"`
+	Report *tmpReport                      `json:"report,omitempty"`
+}
+
+type tmpReport struct {
+	Resources []*tmpResource `json:"resources"`
+}
+
+type tmpError struct {
+	Text     string `json:"_text,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+type tmpResource struct {
+	ID    string `json:"id,omitempty"`
+	Valid *bool  `json:"valid,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// fromTmpError converts a tmpError to a models.CustomRuleError
+func fromTmpError(tmp *tmpError) *models.CustomRuleError {
+	return &models.CustomRuleError{
+		Text:     tmp.Text,
+		Severity: tmp.Severity,
+	}
+}
+
+// fromTmpResource convers a tmpResource to a models.TestCustomRuleOutputResource
+func fromTmpResource(tmp *tmpResource) *models.TestCustomRuleOutputResource {
+	resource := models.TestCustomRuleOutputResource{
+		ID:   tmp.ID,
+		Type: tmp.Type,
+	}
+	if tmp.Valid == nil {
+		resource.Result = models.TestCustomRuleOutputResourceResultUNKNOWN
+	} else if *tmp.Valid {
+		resource.Result = models.TestCustomRuleOutputResourceResultPASS
+	} else {
+		resource.Result = models.TestCustomRuleOutputResultFAIL
+	}
+	return &resource
+}
+
+func getTmpResult(url string) (*tmpResult, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var result tmpResult
+	bytes, err := ioutil.ReadAll(resp.Body)
+	print(string(bytes))
+	if err != nil {
+		return nil, err
+	}
+	json.Unmarshal(bytes, &result)
+	return &result, nil
 }
 
 func NewTestRuleCommand() *cobra.Command {

--- a/cmd/testRule.go
+++ b/cmd/testRule.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/fugue/fugue-client/client/custom_rules"
+	"github.com/fugue/fugue-client/format"
+	"github.com/fugue/fugue-client/models"
+	"github.com/spf13/cobra"
+)
+
+type testRuleOptions struct {
+	ScanID       string
+	ResourceType string
+}
+
+type testRuleResource struct {
+	ID     string
+	Result string
+	Type   string
+}
+
+func NewTestRuleCommand() *cobra.Command {
+	var opts testRuleOptions
+
+	cmd := &cobra.Command{
+		Use:   "rule [rego file]",
+		Short: "Test a custom rule",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+
+			client, auth := getClient()
+
+			regoFile := args[0]
+			regoBytes, err := ioutil.ReadFile(regoFile)
+			if err != nil {
+				CheckErr(err)
+			}
+			regoText := string(regoBytes)
+
+			params := custom_rules.NewTestCustomRuleParams()
+			params.Rule = &models.TestCustomRuleInput{
+				ScanID:       &opts.ScanID,
+				ResourceType: opts.ResourceType,
+				RuleText:     &regoText,
+			}
+
+			resp, err := client.CustomRules.TestCustomRule(params, auth)
+			if err != nil {
+				CheckErr(err)
+			}
+
+			testOutput := resp.Payload
+			if len(testOutput.Errors) > 0 {
+				for _, regoError := range testOutput.Errors {
+					fmt.Println(regoError.Text)
+				}
+				return
+			}
+
+			var rows []interface{}
+			for _, resource := range testOutput.Resources {
+				rows = append(rows, testRuleResource{
+					ID:     resource.ID,
+					Result: resource.Result,
+					Type:   resource.Type,
+				})
+			}
+
+			table, err := format.Table(format.TableOpts{
+				Rows:       rows,
+				Columns:    []string{"ID", "Result", "Type"},
+				ShowHeader: true,
+			})
+			CheckErr(err)
+
+			for _, tableRow := range table {
+				fmt.Println(tableRow)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ScanID, "scan", "", "Scan ID")
+	cmd.Flags().StringVar(&opts.ResourceType, "resource-type", "", "Resource type")
+
+	cmd.MarkFlagRequired("scan")
+	cmd.MarkFlagRequired("resource-type")
+
+	return cmd
+}
+
+func init() {
+	testCmd.AddCommand(NewTestRuleCommand())
+}

--- a/models/test_custom_rule_input_scan.go
+++ b/models/test_custom_rule_input_scan.go
@@ -15,6 +15,9 @@ import (
 // swagger:model TestCustomRuleInputScan
 type TestCustomRuleInputScan struct {
 
+	// links
+	Links map[string]string `json:"links,omitempty"`
+
 	// resources
 	Resources interface{} `json:"resources,omitempty"`
 }

--- a/models/test_custom_rule_output.go
+++ b/models/test_custom_rule_output.go
@@ -23,6 +23,9 @@ type TestCustomRuleOutput struct {
 	// errors
 	Errors []*CustomRuleError `json:"errors"`
 
+	// links
+	Links map[string]string `json:"links,omitempty"`
+
 	// resources
 	Resources []*TestCustomRuleOutputResource `json:"resources"`
 


### PR DESCRIPTION
I got a little frustrated with using CURL, since you need to encode the rego within
a JSON blob which involves escaping, not great in `bash` since you need at least
`jq`.  This patch allows you to simply use a normal rego file, e.g.:

    fugue-client test rule --scan SCAN_ID --resource-type AWS.EC2.Vpc my-rule.rego

It also allows you to retrieve the custom rule input:

    fugue-client get rule-input --scan SCAN_ID >resource.json

TODO / questions:

 -  [x] Should retrieving the input be a separate subcommand?  I tried that but the
    UX isn't great since `get rule` is already taken and you'd want something like
    `get rule input` perhaps.
 -  [x] We added the `links` field to the return type.  I need to update the swagger
    definitions in this repository and add that feature.
 -  [ ] Do we need an `-o` flag?  I think most users will pipe `--input` calls to a
    JSON file, especially if we instruct them to do so.