### PR TITLE
[RM-5062] Add additional fugue list environments filters

### DIFF
--- a/client/environments/list_environments_parameters.go
+++ b/client/environments/list_environments_parameters.go
@@ -117,6 +117,11 @@ type ListEnvironmentsParams struct {
 
 	*/
 	OrderDirection *string
+	/*Query
+	  A stringified JSON array of search parameters.
+
+	*/
+	Query *string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -200,6 +205,17 @@ func (o *ListEnvironmentsParams) SetOrderDirection(orderDirection *string) {
 	o.OrderDirection = orderDirection
 }
 
+// WithQuery adds the query to the list environments params
+func (o *ListEnvironmentsParams) WithQuery(query *string) *ListEnvironmentsParams {
+	o.SetQuery(query)
+	return o
+}
+
+// SetQuery adds the query to the list environments params
+func (o *ListEnvironmentsParams) SetQuery(query *string) {
+	o.Query = query
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListEnvironmentsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -266,6 +282,22 @@ func (o *ListEnvironmentsParams) WriteToRequest(r runtime.ClientRequest, reg str
 		qOrderDirection := qrOrderDirection
 		if qOrderDirection != "" {
 			if err := r.SetQueryParam("order_direction", qOrderDirection); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.Query != nil {
+
+		// query param query
+		var qrQuery string
+		if o.Query != nil {
+			qrQuery = *o.Query
+		}
+		qQuery := qrQuery
+		if qQuery != "" {
+			if err := r.SetQueryParam("query", qQuery); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
- Adds additional ability to filter by `--id`, `--arn`, and `--status` in `fugue list environments`
- Adds the ability to search across all environments by name / id / provider using `--search`
- Updates `--name` and `--provider` filters to use new API functionality instead of client side logic

```
fugue list environments --help
Lists details for multiple environments

Usage:
  fugue list environments [flags]

Aliases:
  environments, envs, env

Flags:
      --all                      Retrieve all environments
      --arn string               AWS Role arn filter (substring match)
      --columns strings          Columns to show (default [ID,Name,Provider,Regions,HasBaseline,ScanInterval,ScanStatus])
  -h, --help                     help for environments
      --id string                ID filter (substring match, including provider account identifiers)
      --max-items int            Max items to return (default 100)
      --name string              Name filter (substring match, case insensitive)
      --offset int               Offset into results
      --order-by string          Order by attribute (default "name")
      --order-direction string   Order by direction [asc | desc] (default "asc")
      --provider string          Provider filter
      --search string            Combined filter for id (including provider account identifiers), name, and provider
      --status string            Scan Status filter (exact match)

Global Flags:
      --output string   The formatting style for command output [table | json] (default "table")
 ```