### PR TITLE
[RM-5603 Add scan-failure-exit-code to fugue scan command

### DIFF
--- a/cmd/triggerScan.go
+++ b/cmd/triggerScan.go
@@ -15,7 +15,7 @@ import (
 func NewTriggerScanCommand() *cobra.Command {
 
 	var wait bool
-	var scanFailureExitCode int64
+	var scanFailureExitCode int
 
 	cmd := &cobra.Command{
 		Use:   "scan [environment_id]",
@@ -103,13 +103,13 @@ func NewTriggerScanCommand() *cobra.Command {
 			}
 
 			if(wait && scan.Status == "ERROR") {
-				os.Exit(int(scanFailureExitCode))
+				os.Exit(scanFailureExitCode)
 			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for scan to complete")
-	cmd.Flags().Int64Var(&scanFailureExitCode, "scan-failure-exit-code", 0, "Sets the exit code to raise when a scan fails. Default is 0. Used with the wait flag")
+	cmd.Flags().IntVar(&scanFailureExitCode, "scan-failure-exit-code", 0, "Sets the exit code to raise when a scan fails. Default is 0. Used with the wait flag")
 
 	return cmd
 }

--- a/cmd/triggerScan.go
+++ b/cmd/triggerScan.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"time"
-
+	"os"
 	"github.com/fugue/fugue-client/client/scans"
 	"github.com/fugue/fugue-client/format"
 	"github.com/fugue/fugue-client/models"
@@ -15,6 +15,7 @@ import (
 func NewTriggerScanCommand() *cobra.Command {
 
 	var wait bool
+	var scanFailureExitCode int64
 
 	cmd := &cobra.Command{
 		Use:   "scan [environment_id]",
@@ -100,10 +101,15 @@ func NewTriggerScanCommand() *cobra.Command {
 			for _, tableRow := range table {
 				fmt.Println(tableRow)
 			}
+
+			if(wait && scan.Status == "ERROR") {
+				os.Exit(int(scanFailureExitCode))
+			}
 		},
 	}
 
 	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for scan to complete")
+	cmd.Flags().Int64Var(&scanFailureExitCode, "scan-failure-exit-code", 0, "Sets the exit code to raise when a scan fails. Default is 0. Used with the wait flag")
 
 	return cmd
 }


### PR DESCRIPTION
Adds a `scan-failure-exit-code` argument which allows caller to set an exit code to be raised in the event a `fugue scan <env>` command results in a scan with status `ERROR`. 

Samples:

```
➜  fugue scan 4037e702-3583-47eb-b52a-6eef439a7238 --wait --scan-failure-exit-code=1
=====================================================
ATTRIBUTE      | VALUE
=====================================================
SCAN_ID        | 28b43614-6396-44b9-83c1-0fc961c0f870
CREATED_AT     | 2021-05-17T15:56:52-05:00
FINISHED_AT    | 2021-05-17T15:58:28-05:00
STATUS         | SUCCESS
MESSAGE        | -
RESOURCE_COUNT | 38
RESOURCE_TYPES | 10
COMPLIANT      | 38
NONCOMPLIANT   | 0
RULES_PASSED   | 51
RULES_FAILED   | 1

➜  echo $?
0

➜  fugue scan 4037e702-3583-47eb-b52a-6eef439a7238 --wait --scan-failure-exit-code=1
=====================================================
ATTRIBUTE      | VALUE
=====================================================
SCAN_ID        | 6b550917-796e-4396-85ac-babeeae2c086
CREATED_AT     | 2021-05-17T15:59:40-05:00
FINISHED_AT    | 2021-05-17T16:00:10-05:00
STATUS         | ERROR
MESSAGE        | SurveyError: Survey failed: FAILED
RESOURCE_COUNT | 0
RESOURCE_TYPES | 0
COMPLIANT      | 0
NONCOMPLIANT   | 0
RULES_PASSED   | 0
RULES_FAILED   | 0

➜  echo $?
1

➜  fugue scan 4037e702-3583-47eb-b52a-6eef439a7238 --wait
=====================================================
ATTRIBUTE      | VALUE
=====================================================
SCAN_ID        | a76d6d26-079d-4339-aeaf-144ce450e405
CREATED_AT     | 2021-05-17T16:00:33-05:00
FINISHED_AT    | 2021-05-17T16:00:52-05:00
STATUS         | ERROR
MESSAGE        | SurveyError: Survey failed: FAILED
RESOURCE_COUNT | 0
RESOURCE_TYPES | 0
COMPLIANT      | 0
NONCOMPLIANT   | 0
RULES_PASSED   | 0
RULES_FAILED   | 0

➜  echo $?
0
```