### PR TITLE
[RM-5867] prefer metadata from __rego__metadoc__ instead of headers

### DIFF
--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -31,6 +31,7 @@ type regoFile struct {
 	Description  string
 	Severity     string
 	Text         string
+	Meta         metadoc.RegoMeta
 }
 
 func (rego *regoFile) ParseText() error {
@@ -76,6 +77,25 @@ func (rego *regoFile) ParseText() error {
 	rego.ResourceType = getHeader("Resource-Type")
 	rego.Description = getHeader("Description")
 	rego.Severity = getHeader("Severity")
+
+	if md, err := metadoc.RegoMetaFromString(rego.Text); err == nil {
+		rego.Meta = *md
+
+		if rego.Meta.Provider != "" {
+			rego.Provider = rego.Meta.Provider
+		}
+		if rego.Meta.ResourceType != "" {
+			rego.ResourceType = rego.Meta.ResourceType
+		}
+		if rego.Meta.Description != "" {
+			rego.Description = rego.Meta.Description
+		}
+		if rego.Meta.Severity != "" {
+			rego.Severity = rego.Meta.Severity
+		}
+	} else {
+		return err
+	}
 
 	// Throw errors if things are missing.
 	if rego.ResourceType == "" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/fatih/structs v1.1.0
-	github.com/fugue/regula v1.3.3-0.20210913151108-62a24084ced7
+	github.com/fugue/regula v1.3.3-0.20210915131409-5c6ddce3aa6a
 	github.com/go-openapi/errors v0.19.6
 	github.com/go-openapi/runtime v0.19.29
 	github.com/go-openapi/strfmt v0.19.5

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fugue/regula v1.3.3-0.20210913151108-62a24084ced7 h1:VsGXA3cjSck9IDtuFZ3oCHsTsvGi8WFN7lja0aAii2Y=
 github.com/fugue/regula v1.3.3-0.20210913151108-62a24084ced7/go.mod h1:pnB6KC++s30MKMEBydivIFOvLuDzDn+bEOflqZ7U2Rw=
+github.com/fugue/regula v1.3.3-0.20210915131409-5c6ddce3aa6a h1:h+zSZmOfjHZPF458dC9z4LEFAyFfzsCYxfhX1byw0FA=
+github.com/fugue/regula v1.3.3-0.20210915131409-5c6ddce3aa6a/go.mod h1:pnB6KC++s30MKMEBydivIFOvLuDzDn+bEOflqZ7U2Rw=
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
 github.com/fzipp/gocyclo v0.3.1/go.mod h1:DJHO6AUmbdqj2ET4Z9iArSuwWgYDRryYt2wASxc7x3E=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=


### PR DESCRIPTION
~Note that this builds on #40, so you probably want to look only at the last commit instead of both.  Unless you're looking at this after #40 has been merged, in which case I'll likely have rebased it on top of the new master :)~

Now that Regula supports having everything in the `__rego__metadoc__` instead of the old style headers (e.g., `# Provider AWS`) we can use that when syncing custom rules so it's not necessary to mix headers (for the provider) and metadoc (for the families).

Here is the rule I've been testing with:

```
__rego__metadoc__ := {
  "id": "FG_R00011",
  "title": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https",
  "description": "CloudFront viewer protocol policy should be set to https-only or redirect-to-https. CloudFront connections should be encrypted during transmission over networks that can be accessed by malicious individuals. A CloudFront distribution should only use HTTPS or Redirect HTTP to HTTPS for communication between viewers and CloudFront.",
  "custom": {
    "severity": "Medium",
    "families": [
      "More rules",
      "e6f9b788-1841-4466-8db7-28d2f08da2ff"
    ],
    "provider": "AWS"
  }
}

resource_type = "AWS.EC2.Instance"

approved_amis = {
  "ami-04b762b4289fba92b"
}

allow {
    ami = input.ami  # Pull out AMIs
    approved_amis[ami]  # Assert
}
```