### PR TITLE
[RM-6224] Fugue Sync Rules removes Family mapping

### DIFF
--- a/cmd/syncRules.go
+++ b/cmd/syncRules.go
@@ -240,16 +240,20 @@ func NewSyncRulesCommand() *cobra.Command {
 					if err != nil {
 						log.Fatal(err)
 					}
-					for _, family := range md.Families {
-						if _, err := uuid.Parse(family); err == nil {
-							ruleFamilies = append(ruleFamilies, family)
-						} else {
-							if familyUUID, ok := familyToUUID(family); !ok {
-								log.Fatalf("Unable to find family '%s' (referenced in '%s').", family, path)
+					if len(md.Families) != 0 {
+						for _, family := range md.Families {
+							if _, err := uuid.Parse(family); err == nil {
+								ruleFamilies = append(ruleFamilies, family)
 							} else {
-								ruleFamilies = append(ruleFamilies, familyUUID)
+								if familyUUID, ok := familyToUUID(family); !ok {
+									log.Fatalf("Unable to find family '%s' (referenced in '%s').", family, path)
+								} else {
+									ruleFamilies = append(ruleFamilies, familyUUID)
+								}
 							}
 						}
+					} else {
+						ruleFamilies = make([]string, 0)
 					}
 				} else {
 					ruleFamilies = targetFamilies


### PR DESCRIPTION
<!-- Title:
    For PRs not ready to merge include "[WIP]"

    Must include JIRA ticket reference(s) "[RM-XXXX]"

    Include a short summary, eg:
    "[RM-XXXX] Fixes random number generation"
-->

## Description

This PR fixes the issue where if you assign a compliance family in the Rego metadoc, run `fugue sync rules`, then remove the family from the metadoc property, run `fugue sync rules` again, the family mapping is not removed in the SaaS.

The problem in the code was that when metadoc Families list read from the `rule text` is null, it would be passed to the API as null, instead of an empty string array. This resulted in the API not correctly updating the families mapping. A check has been added to see if metadoc has a family list, and if not, the null string array is now converted correctly to an empty string array.

## Types of Changes

- [ ] Database migration
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Non-functional (docs, refactoring, etc)
- [ ] This change requires a documentation update

## JIRA

https://luminal.atlassian.net/browse/RM-6224


## Testing

Manually tested with changes to metadoc and ran `fugue sync rules `


