### PR TITLE
[CLOUD-252] Still display header when no rows

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fatih/structs"
 	"strings"
 	"unicode"
+
+	"github.com/fatih/structs"
 )
 
 func getRowMaps(rows []interface{}) []map[string]interface{} {
@@ -60,14 +61,11 @@ func extractColumn(rows [][]string, column int) []string {
 }
 
 func columnWidths(rows [][]string, columnLabels []string, includeCols bool, maxCellLength int) []int {
-	if len(rows) == 0 {
-		return nil
-	}
 	columnCount := len(columnLabels)
 
 	widths := make([]int, columnCount)
 
-	if includeCols {
+	if includeCols || len(rows) == 0 {
 		for i, label := range columnLabels {
 			widths[i] = len(label)
 		}
@@ -115,10 +113,6 @@ type TableOpts struct {
 // Table builds a text table from the given data items and chosen columns.
 // It returns a list of rows that can be printed.
 func Table(opts TableOpts) ([]string, error) {
-
-	if len(opts.Rows) == 0 {
-		return nil, errors.New("No rows to display")
-	}
 	if len(opts.Columns) == 0 {
 		return nil, errors.New("No columns to display")
 	}


### PR DESCRIPTION
This PR changes the behavior of the table formatter to still display the table header when there are no rows to display rather than exiting non-zero with the message `error: No rows to display`:

```
go run main.go test rule --scan c772cec3-31fa-40bc-82f8-5f365eb792bf --resource-type "DEFINED_IN_CODE" ./rule.rego
==================
ID | RESULT | TYPE
==================
```
